### PR TITLE
Local backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ todo.md
 .update/
 # Node modules
 node_modules/
+# Runtime local backup files
+local_backups/

--- a/BACKUP_FEATURE.md
+++ b/BACKUP_FEATURE.md
@@ -1,8 +1,10 @@
-# GitHub Gists Auto-Backup Feature
+# Backup Feature (GitHub + Local)
 
 ## 🎉 Implementation Complete!
 
-Writingway 2 now has automatic cloud backup using GitHub Gists.
+Writingway 2 supports automatic backups using:
+- GitHub Gists (cloud)
+- Local JSON files stored in `./local_backups/` by default
 
 ## ✨ Features
 
@@ -10,7 +12,7 @@ Writingway 2 now has automatic cloud backup using GitHub Gists.
 
 1. **Manual Backup**
    - Click "Backup Now" to save immediately
-   - Creates/updates a private GitHub Gist
+   - Saves to the selected backup target (GitHub Gist or local JSON file)
 
 2. **Auto-Backup**
    - Automatic backup every 5 minutes when enabled
@@ -18,8 +20,9 @@ Writingway 2 now has automatic cloud backup using GitHub Gists.
    - Shows status in sidebar when active
 
 3. **Version History**
-   - GitHub keeps unlimited versions of your backups
-   - View all backup timestamps
+   - View backup history and timestamps
+   - GitHub mode uses Gist revision history
+   - Local mode uses timestamped files in the configured backup directory
    - Restore from any previous version
 
 4. **Restore Functionality**
@@ -28,9 +31,9 @@ Writingway 2 now has automatic cloud backup using GitHub Gists.
    - Full project recovery (chapters, scenes, content, compendium, prompts)
 
 5. **Simple Setup**
-   - Clear step-by-step instructions in the UI
-   - Just paste your GitHub token
-   - Works immediately
+   - Clear setup instructions in the UI
+   - Choose cloud or local backup mode
+   - GitHub token is needed only for cloud mode
 
 6. **Security & Privacy**
    - All Gists are private by default
@@ -38,27 +41,38 @@ Writingway 2 now has automatic cloud backup using GitHub Gists.
    - No storage limits
    - You control your data
 
+7. **Local Backups**
+   - Save backups directly to your local `./local_backups/` folder by default
+   - Uses local server API endpoints
+   - Backup directory is configurable at server startup with `--backup-dir <path>`
+   - No external account or token required
+
 ## 🚀 How to Use
 
 ### Initial Setup
 
 1. Start Writingway 2 with `start.bat`
 2. Open the main menu (☰)
-3. Click "☁️ Cloud Backup"
-4. Follow the instructions to create a GitHub token
-5. Paste your token and click "Save Settings"
-6. Enable "Enable automatic backup"
-7. Done! Your project will backup every 5 minutes
+3. Click "💾 Backups"
+4. Choose backup location:
+   - **Cloud (GitHub Gists)**: paste a GitHub token
+   - **Local Folder (`./local_backups` by default)**: no token needed
+5. Click "Save Settings"
+6. Optionally enable automatic backup (every 5 minutes)
+7. Optional: change local backup directory when starting server, for example:
+   - `python main.py --backup-dir ./my_backups`
+   - `./start.sh ./my_backups` (Mac/Linux)
+   - `start.bat my_backups` (Windows)
 
 ### Backup Now
 
-1. Open main menu → "☁️ Cloud Backup"
+1. Open main menu → "💾 Backups"
 2. Click "Backup Now"
 3. Wait for confirmation
 
 ### Restore from Backup
 
-1. Open main menu → "☁️ Cloud Backup"
+1. Open main menu → "💾 Backups"
 2. Click "📥 Restore from Backup"
 3. Select a backup version
 4. Click "Restore"
@@ -69,11 +83,13 @@ Writingway 2 now has automatic cloud backup using GitHub Gists.
 
 ### New Files
 - `src/modules/github-backup.js` - Backup module
+- `main.py` - Local web server with backup API endpoints
 - `BACKUP_TESTING.md` - Testing guide
 
 ### Modified Files
 - `src/app.js` - Added backup state variables and methods
 - `main.html` - Added backup UI (settings panel, restore modal, menu button, status indicator)
+- `start.sh` / `start.bat` - Use `main.py` server instead of plain `http.server`
 
 ## 🔧 Technical Details
 
@@ -92,12 +108,18 @@ Each backup includes:
 - No storage limits
 - Unlimited version history
 - Accessible from https://gist.github.com/
+- Local mode stores versioned JSON backup files in `./local_backups/` by default
+- Set a custom location with `--backup-dir <path>` on server startup
 
 ### API Usage
 - Uses GitHub REST API v3
 - Only requires `gist` permission
 - Token stored in localStorage
 - Auto-backup timer: 5 minutes
+- Local mode uses:
+  - `POST /api/backups`
+  - `GET /api/backups?projectId=<id>`
+  - `GET /api/backups/<backup_id>`
 
 ### Key Functions
 
@@ -105,8 +127,11 @@ Each backup includes:
 - `validateToken()` - Validates GitHub token
 - `exportProjectData()` - Exports all project data
 - `backupToGist()` - Creates or updates Gist
+- `backupToLocal()` - Saves backup JSON to local server
 - `listBackups()` - Fetches version history
+- `listLocalBackups()` - Lists local backups
 - `restoreFromBackup()` - Restores from specific version
+- `restoreFromLocalBackup()` - Restores from local backup payload
 - `restoreProjectData()` - Writes backup data to database
 - `startAutoBackup()` - Starts 5-minute timer
 - `stopAutoBackup()` - Stops timer
@@ -137,7 +162,7 @@ Quick test:
 ## 🎯 User Experience
 
 ### UI Location
-- **Main Menu**: "☁️ Cloud Backup" button
+- **Main Menu**: "💾 Backups" button
 - **Sidebar**: Small status indicator when auto-backup is enabled
 - **Settings Panel**: Slide-in from right with full controls
 - **Restore Modal**: Centered overlay with version list

--- a/main.html
+++ b/main.html
@@ -246,7 +246,7 @@
                                 <button @click.stop="showAISettings = true; mainMenuOpen=false">⚙️ AI Settings</button>
                                 <button @click.stop="showPromptsPanel = true; mainMenuOpen=false">📝 Manage
                                     Prompts</button>
-                                <button @click.stop="openBackupSettings(); mainMenuOpen=false">☁️ Cloud Backup</button>
+                                <button @click.stop="openBackupSettings(); mainMenuOpen=false">💾 Backups</button>
                                 <div style="border-top:1px solid var(--border);margin:6px 0"></div>
                                 <button @click.stop="checkForUpdates(); mainMenuOpen=false"
                                     :disabled="checkingForUpdates">
@@ -279,7 +279,7 @@
                             style="cursor:pointer;padding:8px 16px;border-radius:8px;transition:background 0.2s;font-size:12px;"
                             @click="openBackupSettings()" @mouseenter="$el.style.background='rgba(76,175,80,0.1)'"
                             @mouseleave="$el.style.background='transparent'" title="Click for backup settings">
-                            <span>☁️</span>
+                            <span x-text="backupProvider === 'local' ? '💾' : '☁️'"></span>
                             <span x-text="backupStatus || 'Auto-backup active'"></span>
                         </div>
                     </div>
@@ -423,7 +423,7 @@
                 <!-- Main Content Area (wrapper for banner + editor) -->
                 <div class="main-content-area">
                     <!-- Auto-Backup Warning Banner (non-dismissable) -->
-                    <div x-show="!backupEnabled || !githubToken" x-cloak class="backup-warning-banner">
+                    <div x-show="!backupEnabled || (backupProvider === 'github' && !githubToken)" x-cloak class="backup-warning-banner">
                         AUTO BACKUP NOT ENABLED! Data will be lost on deleting the browser cache or site data.
                     </div>
 
@@ -1809,14 +1809,23 @@
             </div>
         </div>
 
-        <!-- GitHub Backup Settings Panel -->
+        <!-- Backup Settings Panel -->
         <div class="slide-panel-right" :class="{ 'open': showBackupSettings }" x-cloak>
             <div class="slide-panel-header">
-                <h3 style="margin:0;">☁️ Cloud Backup</h3>
+                <h3 style="margin:0;">💾 Backups</h3>
                 <button class="btn btn-secondary" @click="closeBackupSettings()">Close</button>
             </div>
             <div class="slide-panel-body" style="padding:20px;">
-                <div
+                <div style="margin-bottom:20px;">
+                    <label style="display:block;font-weight:600;margin-bottom:8px;">Backup Location</label>
+                    <select x-model="backupProvider"
+                        style="width:100%;padding:10px;background:var(--input-bg);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);">
+                        <option value="local">Local Folder (default: ./local_backups)</option>
+                        <option value="github">Cloud (GitHub Gists)</option>
+                    </select>
+                </div>
+
+                <div x-show="backupProvider === 'github'"
                     style="background:rgba(74,158,255,0.1);border:1px solid rgba(74,158,255,0.3);border-radius:8px;padding:16px;margin-bottom:24px;">
                     <h4 style="margin:0 0 12px 0;color:var(--text-primary);">Setup Instructions</h4>
                     <ol style="margin:0;padding-left:20px;line-height:1.8;font-size:14px;">
@@ -1833,13 +1842,21 @@
                     </ol>
                 </div>
 
-                <div style="margin-bottom:20px;">
+                <div x-show="backupProvider === 'github'" style="margin-bottom:20px;">
                     <label style="display:block;font-weight:600;margin-bottom:8px;">GitHub Token</label>
                     <input type="password" x-model="githubToken" placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
                         style="width:100%;padding:10px;background:var(--input-bg);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-family:monospace;font-size:13px;">
                     <p style="font-size:12px;color:var(--text-secondary);margin-top:8px;">
                         <span x-show="githubUsername" style="color:#4caf50;">✓ Connected as: <strong
                                 x-text="githubUsername"></strong></span>
+                    </p>
+                </div>
+
+                <div x-show="backupProvider === 'local'"
+                    style="margin-bottom:20px;padding:12px;background:rgba(76,175,80,0.1);border:1px solid rgba(76,175,80,0.3);border-radius:6px;">
+                    <p style="margin:0;font-size:13px;line-height:1.6;">
+                        Local backups are saved through the local web server (default folder: <code>./local_backups/</code>).
+                        You can override this with the server startup flag <code>--backup-dir &lt;path&gt;</code>.
                     </p>
                 </div>
 
@@ -1870,7 +1887,8 @@
 
                 <div style="border-top:1px solid var(--border);padding-top:20px;">
                     <button class="btn btn-secondary" @click="openRestoreModal()"
-                        :disabled="!githubToken || !currentProjectGistId" style="width:100%;">
+                        :disabled="backupProvider === 'github' ? (!githubToken || !currentProjectGistId) : !currentProject"
+                        style="width:100%;">
                         📥 Restore from Backup
                     </button>
                 </div>
@@ -1878,8 +1896,10 @@
                 <div
                     style="margin-top:20px;padding:16px;background:rgba(255,193,7,0.1);border:1px solid rgba(255,193,7,0.3);border-radius:8px;">
                     <p style="margin:0;font-size:13px;line-height:1.6;">
-                        <strong>Note:</strong> Each project is backed up to its own private GitHub Gist.
-                        Backups include all chapters, scenes, content, compendium entries, and prompts.
+                        <strong>Note:</strong>
+                        <span x-show="backupProvider === 'github'">Each project is backed up to its own private GitHub Gist.</span>
+                        <span x-show="backupProvider === 'local'">Each backup is saved as a JSON file (default: <code>./local_backups/</code>; configurable with <code>--backup-dir</code>).</span>
+                        Backups include chapters, scenes, content, compendium entries, and prompts.
                     </p>
                 </div>
             </div>

--- a/main.py
+++ b/main.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Writingway local web server.
+
+Serves static files (like `python -m http.server`) and adds local backup APIs.
+Default backup directory is `./local_backups` (override with `--backup-dir`):
+- POST /api/backups
+- GET  /api/backups?projectId=<id>
+- GET  /api/backups/<backup_id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+
+ROOT_DIR = Path(__file__).resolve().parent
+DEFAULT_BACKUP_DIR_NAME = "local_backups"
+BACKUPS_DIR = ROOT_DIR / DEFAULT_BACKUP_DIR_NAME
+MAX_BODY_BYTES = 25 * 1024 * 1024  # 25 MB
+SAFE_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def slugify(value: str, fallback: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", value or "").strip("._-")
+    cleaned = cleaned[:80]
+    return cleaned or fallback
+
+
+def resolve_backup_dir(raw_value: str) -> Path:
+    candidate = Path(raw_value).expanduser()
+    if not candidate.is_absolute():
+        candidate = ROOT_DIR / candidate
+    return candidate
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(path)
+
+
+class WritingwayRequestHandler(SimpleHTTPRequestHandler):
+    """Static file handler with local backup JSON endpoints."""
+
+    server_version = "WritingwayHTTP/1.0"
+
+    def __init__(self, *args: Any, directory: str | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, directory=directory or str(ROOT_DIR), **kwargs)
+
+    def do_GET(self) -> None:  # noqa: N802 - http.server naming
+        parsed = urlparse(self.path)
+        path = parsed.path
+
+        if path == "/api/health":
+            self._send_json(
+                HTTPStatus.OK,
+                {
+                    "ok": True,
+                    "service": "writingway-local-server",
+                    "backupsDir": str(BACKUPS_DIR),
+                },
+            )
+            return
+
+        if path == "/api/backups":
+            project_id = parse_qs(parsed.query).get("projectId", [""])[0]
+            backups = self._list_backups(project_id=project_id or None)
+            self._send_json(HTTPStatus.OK, {"success": True, "backups": backups})
+            return
+
+        if path.startswith("/api/backups/"):
+            backup_id = unquote(path.removeprefix("/api/backups/")).strip()
+            self._handle_get_backup(backup_id)
+            return
+
+        super().do_GET()
+
+    def do_POST(self) -> None:  # noqa: N802 - http.server naming
+        parsed = urlparse(self.path)
+        if parsed.path != "/api/backups":
+            self._send_json(HTTPStatus.NOT_FOUND, {"success": False, "error": "Not found"})
+            return
+
+        payload = self._read_json_body()
+        if payload is None:
+            return
+
+        if not isinstance(payload, dict):
+            self._send_json(HTTPStatus.BAD_REQUEST, {"success": False, "error": "Body must be a JSON object"})
+            return
+
+        project = payload.get("project")
+        if not isinstance(project, dict) or not project.get("id"):
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"success": False, "error": "Missing required field: project.id"},
+            )
+            return
+
+        project_id = slugify(str(project.get("id", "")), "project")
+        project_name = slugify(str(project.get("name", "")), "project")
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        suffix = uuid.uuid4().hex[:8]
+        backup_id = f"{project_id}__{timestamp}__{project_name}__{suffix}"
+        backup_path = BACKUPS_DIR / f"{backup_id}.json"
+
+        try:
+            BACKUPS_DIR.mkdir(parents=True, exist_ok=True)
+            serialized = json.dumps(payload, indent=2, ensure_ascii=False)
+            backup_path.write_text(serialized + "\n", encoding="utf-8")
+        except OSError as exc:
+            self._send_json(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"success": False, "error": f"Failed to write backup file: {exc}"},
+            )
+            return
+
+        exported_at = payload.get("exportedAt") or datetime.now(timezone.utc).isoformat()
+        self._send_json(
+            HTTPStatus.CREATED,
+            {
+                "success": True,
+                "backup": {
+                    "id": backup_id,
+                    "version": backup_id,
+                    "timestamp": exported_at,
+                    "url": f"/api/backups/{backup_id}",
+                    "file": display_path(backup_path),
+                },
+            },
+        )
+
+    def _handle_get_backup(self, backup_id: str) -> None:
+        if not SAFE_ID_RE.fullmatch(backup_id):
+            self._send_json(HTTPStatus.BAD_REQUEST, {"success": False, "error": "Invalid backup ID"})
+            return
+
+        backup_path = BACKUPS_DIR / f"{backup_id}.json"
+        if not backup_path.exists() or not backup_path.is_file():
+            self._send_json(HTTPStatus.NOT_FOUND, {"success": False, "error": "Backup not found"})
+            return
+
+        try:
+            payload = json.loads(backup_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            self._send_json(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"success": False, "error": f"Failed to read backup data: {exc}"},
+            )
+            return
+
+        self._send_json(HTTPStatus.OK, payload)
+
+    def _list_backups(self, project_id: str | None = None) -> list[dict[str, Any]]:
+        BACKUPS_DIR.mkdir(parents=True, exist_ok=True)
+
+        entries: list[dict[str, Any]] = []
+        for path in BACKUPS_DIR.glob("*.json"):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+
+            project = payload.get("project") if isinstance(payload, dict) else None
+            if not isinstance(project, dict):
+                continue
+
+            pid = str(project.get("id", ""))
+            if project_id and pid != project_id:
+                continue
+
+            mtime = path.stat().st_mtime
+            timestamp = payload.get("exportedAt")
+            if not isinstance(timestamp, str) or not timestamp:
+                timestamp = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+
+            backup_id = path.stem
+            entries.append(
+                {
+                    "id": backup_id,
+                    "version": backup_id,
+                    "timestamp": timestamp,
+                    "url": f"/api/backups/{backup_id}",
+                    "projectId": pid,
+                    "projectName": str(project.get("name", "")),
+                    "size": path.stat().st_size,
+                    "_mtime": mtime,
+                }
+            )
+
+        entries.sort(key=lambda item: item.get("_mtime", 0.0), reverse=True)
+        for item in entries:
+            item.pop("_mtime", None)
+        return entries
+
+    def _read_json_body(self) -> dict[str, Any] | list[Any] | None:
+        raw_length = self.headers.get("Content-Length")
+        if raw_length is None:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"success": False, "error": "Missing Content-Length header"})
+            return None
+
+        try:
+            length = int(raw_length)
+        except ValueError:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"success": False, "error": "Invalid Content-Length header"})
+            return None
+
+        if length < 0 or length > MAX_BODY_BYTES:
+            self._send_json(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, {"success": False, "error": "Request body too large"})
+            return None
+
+        body = self.rfile.read(length)
+        try:
+            return json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self._send_json(HTTPStatus.BAD_REQUEST, {"success": False, "error": "Body must be valid UTF-8 JSON"})
+            return None
+
+    def _send_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(int(status))
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Writingway local web server")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8000, help="TCP port to bind (default: 8000)")
+    parser.add_argument(
+        "--backup-dir",
+        default=DEFAULT_BACKUP_DIR_NAME,
+        help=f"Backup directory path (default: {DEFAULT_BACKUP_DIR_NAME})",
+    )
+    return parser
+
+
+def main() -> None:
+    global BACKUPS_DIR
+    args = build_arg_parser().parse_args()
+    BACKUPS_DIR = resolve_backup_dir(args.backup_dir)
+    BACKUPS_DIR.mkdir(parents=True, exist_ok=True)
+
+    server = ThreadingHTTPServer((args.host, args.port), WritingwayRequestHandler)
+    print(f"Writingway web server listening on http://{args.host}:{args.port}")
+    print("Static root:", ROOT_DIR)
+    print("Backup directory:", BACKUPS_DIR)
+    print("Backup API:")
+    print("  POST /api/backups")
+    print("  GET  /api/backups?projectId=<id>")
+    print("  GET  /api/backups/<backup_id>")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+        print("\nServer stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app.js
+++ b/src/app.js
@@ -2135,7 +2135,7 @@ document.addEventListener('alpine:init', () => {
                 await this.loadChapters();
             },
 
-            // ========== GitHub Backup Methods ==========
+            // ========== Backup Methods ==========
 
             async openBackupSettings() {
                 this.showBackupSettings = true;
@@ -2146,8 +2146,10 @@ document.addEventListener('alpine:init', () => {
             },
 
             async saveBackupSettings() {
-                // Validate token first
-                if (this.githubToken) {
+                const isGitHubMode = String(this.backupProvider || '').trim().toLowerCase() === 'github';
+
+                // Validate token only for GitHub mode.
+                if (isGitHubMode && this.githubToken) {
                     this.backupStatus = 'Validating token...';
                     const result = await window.GitHubBackup.validateToken(this.githubToken);
 
@@ -2160,11 +2162,23 @@ document.addEventListener('alpine:init', () => {
                     this.githubUsername = result.username;
                 }
 
+                // If GitHub mode + auto-backup, require token.
+                if (isGitHubMode && this.backupEnabled && !this.githubToken) {
+                    alert('Please configure a GitHub token before enabling GitHub auto-backup.');
+                    this.backupStatus = 'Token required';
+                    return;
+                }
+
+                // Local mode doesn't use GitHub identity.
+                if (!isGitHubMode) {
+                    this.githubUsername = '';
+                }
+
                 // Save settings
                 window.GitHubBackup.saveBackupSettings(this);
 
                 // Start or stop auto-backup based on enabled state
-                if (this.backupEnabled && this.githubToken) {
+                if (this.backupEnabled) {
                     window.GitHubBackup.startAutoBackup(this);
                     this.backupStatus = 'Auto-backup enabled';
                 } else {
@@ -2176,13 +2190,21 @@ document.addEventListener('alpine:init', () => {
             },
 
             async backupNow() {
-                if (!this.githubToken || !this.currentProject) {
-                    alert('Please configure GitHub token and select a project first.');
+                if (!this.currentProject) {
+                    alert('Please select a project first.');
+                    return;
+                }
+
+                const isGitHubMode = String(this.backupProvider || '').trim().toLowerCase() === 'github';
+                if (isGitHubMode && !this.githubToken) {
+                    alert('Please configure GitHub token first.');
                     return;
                 }
 
                 this.backupStatus = 'Backing up...';
-                const result = await window.GitHubBackup.backupToGist(this);
+                const result = isGitHubMode
+                    ? await window.GitHubBackup.backupToGist(this)
+                    : await window.GitHubBackup.backupToLocal(this);
 
                 if (result.success) {
                     this.lastBackupTime = new Date();
@@ -2199,16 +2221,29 @@ document.addEventListener('alpine:init', () => {
             },
 
             async openRestoreModal() {
-                if (!this.githubToken || !this.currentProjectGistId) {
-                    alert('No backup configured for this project.');
+                if (!this.currentProject) {
+                    alert('Please select a project first.');
+                    return;
+                }
+
+                const isGitHubMode = String(this.backupProvider || '').trim().toLowerCase() === 'github';
+                if (isGitHubMode && (!this.githubToken || !this.currentProjectGistId)) {
+                    alert('No GitHub backup configured for this project.');
                     return;
                 }
 
                 this.backupStatus = 'Loading backups...';
-                const result = await window.GitHubBackup.listBackups(this);
+                const result = isGitHubMode
+                    ? await window.GitHubBackup.listBackups(this)
+                    : await window.GitHubBackup.listLocalBackups(this);
 
                 if (result.success) {
-                    this.backupList = result.backups;
+                    this.backupList = result.backups || [];
+                    if (this.backupList.length === 0) {
+                        this.backupStatus = '';
+                        alert('No backups found for this project.');
+                        return;
+                    }
                     this.showRestoreModal = true;
                     this.backupStatus = '';
                 } else {
@@ -2222,13 +2257,16 @@ document.addEventListener('alpine:init', () => {
                 this.backupList = [];
             },
 
-            async restoreBackup(versionUrl) {
+            async restoreBackup(backupRef) {
                 if (!confirm('This will replace your current project with the backup. Continue?')) {
                     return;
                 }
 
                 this.backupStatus = 'Restoring...';
-                const result = await window.GitHubBackup.restoreFromBackup(this, versionUrl);
+                const isGitHubMode = String(this.backupProvider || '').trim().toLowerCase() === 'github';
+                const result = isGitHubMode
+                    ? await window.GitHubBackup.restoreFromBackup(this, backupRef)
+                    : await window.GitHubBackup.restoreFromLocalBackup(this, backupRef);
 
                 if (result.success) {
                     this.backupStatus = 'Restored';

--- a/src/modules/github-backup.js
+++ b/src/modules/github-backup.js
@@ -1,13 +1,18 @@
-// GitHub Gists Auto-Backup Module
-// Handles automatic backup to GitHub Gists and restore functionality
+// Backup Module
+// Handles GitHub Gist backups and local file backups via the local web server.
 
 (function () {
     const BACKUP_INTERVAL = 5 * 60 * 1000; // 5 minutes
+    const LOCAL_BACKUP_API = '/api/backups';
     let backupIntervalId = null;
 
     const GitHubBackup = {
+        isGitHubMode(app) {
+            return String(app.backupProvider || '').trim().toLowerCase() === 'github';
+        },
+
         /**
-         * Validate GitHub token
+         * Validate GitHub token.
          */
         async validateToken(token) {
             try {
@@ -28,7 +33,7 @@
         },
 
         /**
-         * Export current project data as JSON
+         * Export current project data as JSON.
          */
         async exportProjectData(app) {
             if (!app.currentProject) return null;
@@ -36,18 +41,15 @@
             try {
                 const projectId = app.currentProject.id;
 
-                // Get all data for current project
                 const chapters = await db.chapters.where('projectId').equals(projectId).toArray();
                 const scenes = await db.scenes.where('projectId').equals(projectId).toArray();
 
-                // Get content for all scenes
                 const sceneContents = {};
                 for (const scene of scenes) {
                     const content = await db.content.get(scene.id);
                     sceneContents[scene.id] = content ? content.text : '';
                 }
 
-                // Get compendium entries (handle if table doesn't exist)
                 let compendium = [];
                 try {
                     if (db.compendium) {
@@ -57,7 +59,6 @@
                     console.warn('Could not load compendium:', e);
                 }
 
-                // Get prompts (handle if table doesn't exist)
                 let prompts = [];
                 try {
                     if (db.prompts) {
@@ -84,7 +85,7 @@
         },
 
         /**
-         * Create or update GitHub Gist with backup
+         * Create or update GitHub Gist with backup.
          */
         async backupToGist(app) {
             if (!app.githubToken || !app.currentProject) {
@@ -99,12 +100,9 @@
 
                 const filename = `${app.currentProject.name.replace(/[^a-z0-9]/gi, '_')}_backup.json`;
                 const description = `Writingway Auto-Backup: ${app.currentProject.name}`;
-
-                // Check if gist already exists
                 const gistId = app.currentProjectGistId;
 
                 if (gistId) {
-                    // Update existing gist
                     const response = await fetch(`https://api.github.com/gists/${gistId}`, {
                         method: 'PATCH',
                         headers: {
@@ -133,7 +131,6 @@
                     }
                 }
 
-                // Create new gist
                 const response = await fetch('https://api.github.com/gists', {
                     method: 'POST',
                     headers: {
@@ -169,7 +166,50 @@
         },
 
         /**
-         * List all backup versions from gist history
+         * Save backup to local folder via local server API.
+         * Default server folder is ./local_backups (can be changed with --backup-dir).
+         */
+        async backupToLocal(app) {
+            if (!app.currentProject) {
+                return { success: false, error: 'No project selected' };
+            }
+
+            try {
+                const projectData = await this.exportProjectData(app);
+                if (!projectData) {
+                    return { success: false, error: 'No project data' };
+                }
+
+                const response = await fetch(LOCAL_BACKUP_API, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json'
+                    },
+                    body: JSON.stringify(projectData)
+                });
+
+                const data = await response.json().catch(() => null);
+                if (!response.ok || !data || data.success === false) {
+                    return {
+                        success: false,
+                        error: (data && data.error) ? data.error : `HTTP ${response.status}`
+                    };
+                }
+
+                const backup = data.backup || {};
+                return {
+                    success: true,
+                    backupId: backup.id || '',
+                    backup: backup
+                };
+            } catch (e) {
+                return { success: false, error: e.message };
+            }
+        },
+
+        /**
+         * List backup versions from gist history.
          */
         async listBackups(app) {
             if (!app.githubToken || !app.currentProjectGistId) {
@@ -177,7 +217,6 @@
             }
 
             try {
-                // Get gist with full history
                 const response = await fetch(`https://api.github.com/gists/${app.currentProjectGistId}`, {
                     headers: {
                         'Authorization': `token ${app.githubToken}`,
@@ -190,8 +229,6 @@
                 }
 
                 const gist = await response.json();
-
-                // Get all versions
                 const versions = gist.history || [];
 
                 return {
@@ -209,7 +246,46 @@
         },
 
         /**
-         * Restore from a specific backup version
+         * List local backups for the currently selected project.
+         */
+        async listLocalBackups(app) {
+            if (!app.currentProject) {
+                return { success: false, error: 'No selected project' };
+            }
+
+            try {
+                const projectId = encodeURIComponent(app.currentProject.id);
+                const response = await fetch(`${LOCAL_BACKUP_API}?projectId=${projectId}`, {
+                    headers: {
+                        'Accept': 'application/json'
+                    }
+                });
+
+                const data = await response.json().catch(() => null);
+                if (!response.ok || !data || data.success === false) {
+                    return {
+                        success: false,
+                        error: (data && data.error) ? data.error : `HTTP ${response.status}`
+                    };
+                }
+
+                const rawBackups = Array.isArray(data.backups) ? data.backups : [];
+                return {
+                    success: true,
+                    backups: rawBackups.map(b => ({
+                        version: String(b.version || b.id || ''),
+                        timestamp: b.timestamp || new Date().toISOString(),
+                        url: b.url || `${LOCAL_BACKUP_API}/${encodeURIComponent(String(b.id || ''))}`,
+                        id: b.id || ''
+                    }))
+                };
+            } catch (e) {
+                return { success: false, error: e.message };
+            }
+        },
+
+        /**
+         * Restore from a specific GitHub backup version.
          */
         async restoreFromBackup(app, versionUrl) {
             if (!app.githubToken) {
@@ -237,8 +313,6 @@
                 }
 
                 const backupData = JSON.parse(firstFile.content);
-
-                // Restore project data
                 await this.restoreProjectData(app, backupData);
 
                 return { success: true };
@@ -248,27 +322,57 @@
         },
 
         /**
-         * Restore project data from backup
+         * Restore from a local backup file via local server API.
+         */
+        async restoreFromLocalBackup(app, backupRef) {
+            if (!backupRef) {
+                return { success: false, error: 'No backup reference provided' };
+            }
+
+            try {
+                const url = backupRef.startsWith('/')
+                    ? backupRef
+                    : `${LOCAL_BACKUP_API}/${encodeURIComponent(backupRef)}`;
+
+                const response = await fetch(url, {
+                    headers: {
+                        'Accept': 'application/json'
+                    }
+                });
+
+                const backupData = await response.json().catch(() => null);
+                if (!response.ok || !backupData || backupData.success === false) {
+                    return {
+                        success: false,
+                        error: (backupData && backupData.error) ? backupData.error : `HTTP ${response.status}`
+                    };
+                }
+
+                await this.restoreProjectData(app, backupData);
+                return { success: true };
+            } catch (e) {
+                return { success: false, error: e.message };
+            }
+        },
+
+        /**
+         * Restore project data from backup payload.
          */
         async restoreProjectData(app, backupData) {
             const projectId = backupData.project.id;
 
-            // Update project info
             await db.projects.put(backupData.project);
 
-            // Clear and restore chapters
             await db.chapters.where('projectId').equals(projectId).delete();
             for (const chapter of backupData.chapters) {
                 await db.chapters.add(chapter);
             }
 
-            // Clear and restore scenes
             await db.scenes.where('projectId').equals(projectId).delete();
             for (const scene of backupData.scenes) {
                 await db.scenes.add(scene);
             }
 
-            // Restore scene contents
             for (const [sceneId, text] of Object.entries(backupData.sceneContents)) {
                 const wordCount = text ? text.trim().split(/\s+/).filter(w => w.length > 0).length : 0;
                 await db.content.put({
@@ -278,13 +382,11 @@
                 });
             }
 
-            // Clear and restore compendium
             await db.compendium.where('projectId').equals(projectId).delete();
             for (const entry of backupData.compendium || []) {
                 await db.compendium.add(entry);
             }
 
-            // Clear and restore prompts
             if (backupData.prompts) {
                 await db.prompts.where('projectId').equals(projectId).delete();
                 for (const prompt of backupData.prompts) {
@@ -292,12 +394,11 @@
                 }
             }
 
-            // Reload the project
             await app.selectProject(projectId);
         },
 
         /**
-         * Start auto-backup timer
+         * Start auto-backup timer for current provider.
          */
         startAutoBackup(app) {
             if (backupIntervalId) {
@@ -305,28 +406,32 @@
             }
 
             backupIntervalId = setInterval(async () => {
-                if (app.backupEnabled && app.githubToken && app.currentProject) {
-                    app.backupStatus = 'Backing up...';
-                    const result = await this.backupToGist(app);
+                if (!app.backupEnabled || !app.currentProject) return;
 
-                    if (result.success) {
-                        app.lastBackupTime = new Date();
-                        app.backupStatus = 'Backed up';
-                        if (result.gistId) {
-                            app.currentProjectGistId = result.gistId;
-                            this.saveBackupSettings(app);
-                        }
-                        console.log('✓ Auto-backup successful');
-                    } else {
-                        app.backupStatus = 'Backup failed';
-                        console.error('Auto-backup failed:', result.error);
+                if (this.isGitHubMode(app) && !app.githubToken) return;
+
+                app.backupStatus = 'Backing up...';
+                const result = this.isGitHubMode(app)
+                    ? await this.backupToGist(app)
+                    : await this.backupToLocal(app);
+
+                if (result.success) {
+                    app.lastBackupTime = new Date();
+                    app.backupStatus = 'Backed up';
+                    if (result.gistId) {
+                        app.currentProjectGistId = result.gistId;
                     }
+                    this.saveBackupSettings(app);
+                    console.log('✓ Auto-backup successful');
+                } else {
+                    app.backupStatus = 'Backup failed';
+                    console.error('Auto-backup failed:', result.error);
                 }
             }, BACKUP_INTERVAL);
         },
 
         /**
-         * Stop auto-backup timer
+         * Stop auto-backup timer.
          */
         stopAutoBackup() {
             if (backupIntervalId) {
@@ -336,11 +441,12 @@
         },
 
         /**
-         * Save backup settings to localStorage
+         * Save backup settings to localStorage.
          */
         saveBackupSettings(app) {
             try {
                 const settings = {
+                    provider: this.isGitHubMode(app) ? 'github' : 'local',
                     enabled: app.backupEnabled,
                     token: app.githubToken,
                     gistId: app.currentProjectGistId,
@@ -353,24 +459,39 @@
         },
 
         /**
-         * Load backup settings from localStorage
+         * Load backup settings from localStorage.
          */
         loadBackupSettings(app) {
             try {
                 const saved = localStorage.getItem('writingway:backupSettings');
-                if (saved) {
-                    const settings = JSON.parse(saved);
-                    app.backupEnabled = settings.enabled || false;
-                    app.githubToken = settings.token || '';
-                    app.currentProjectGistId = settings.gistId || '';
-                    app.githubUsername = settings.username || '';
+                if (!saved) return;
 
-                    // Delay auto-backup start to avoid blocking initialization
-                    if (app.backupEnabled && app.githubToken) {
-                        setTimeout(() => {
-                            this.startAutoBackup(app);
-                        }, 5000); // Start after 5 seconds
-                    }
+                const settings = JSON.parse(saved);
+
+                // Backward compatibility:
+                // older versions had no provider field and were GitHub-only.
+                const provider = String(settings.provider || '').trim().toLowerCase();
+                if (provider === 'local' || provider === 'github') {
+                    app.backupProvider = provider;
+                } else if (settings.token || settings.gistId || settings.username) {
+                    app.backupProvider = 'github';
+                } else {
+                    app.backupProvider = 'local';
+                }
+
+                app.backupEnabled = settings.enabled || false;
+                app.githubToken = settings.token || '';
+                app.currentProjectGistId = settings.gistId || '';
+                app.githubUsername = settings.username || '';
+
+                const shouldAutoStart = app.backupEnabled && (
+                    !this.isGitHubMode(app) || !!app.githubToken
+                );
+
+                if (shouldAutoStart) {
+                    setTimeout(() => {
+                        this.startAutoBackup(app);
+                    }, 5000);
                 }
             } catch (e) {
                 console.error('Failed to load backup settings:', e);

--- a/src/state/app-state.js
+++ b/src/state/app-state.js
@@ -211,6 +211,7 @@ function createAppState() {
         modelsFetched: false, // Whether we've already fetched models for current provider
 
         // ========== GitHub Backup State ==========
+        backupProvider: 'local', // 'local' or 'github'
         githubToken: '',
         githubUsername: '',
         backupEnabled: false,

--- a/start.bat
+++ b/start.bat
@@ -9,6 +9,10 @@ echo   Starting Writingway 2.0...
 echo ================================
 echo.
 
+REM Optional first argument: backup directory (default: local_backups)
+set "BACKUP_DIR=%~1"
+if "%BACKUP_DIR%"=="" set "BACKUP_DIR=local_backups"
+
 REM ========================================
 REM  SECTION 1: Apply Staged Update
 REM ========================================
@@ -230,6 +234,7 @@ echo.
 echo Web UI: http://localhost:8000/main.html
 echo AI API: http://localhost:8080
 echo Updater: http://localhost:8001
+echo Backups: %BACKUP_DIR%
 echo.
 
 REM Wait 3 seconds before opening browser (gives servers time to stabilize)
@@ -245,8 +250,8 @@ echo.
 REM Open browser
 start "" http://localhost:8000/main.html
 
-REM Start Python web server (blocks here)
-python -m http.server 8000
+REM Start Writingway web server (static files + local backup API)
+python main.py --host 127.0.0.1 --port 8000 --backup-dir "%BACKUP_DIR%"
 
 REM Cleanup when Python server stops
 echo.

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,9 @@ echo "  Starting Writingway 2.0..."
 echo "================================"
 echo ""
 
+# Optional CLI argument: backup directory (default: local_backups)
+BACKUP_DIR="${1:-local_backups}"
+
 # Check if llama-server exists (in llama subfolder)
 if [ ! -f "./llama/llama-server" ]; then
     echo "[!] llama-server not found!"
@@ -152,6 +155,7 @@ echo "  * Keep this terminal open while using Writingway"
 echo ""
 echo "Web UI: http://localhost:8000/main.html"
 echo "AI API: http://localhost:8080"
+echo "Backups: ${BACKUP_DIR}"
 echo ""
 
 # Wait 3 seconds before opening browser
@@ -172,8 +176,8 @@ elif command -v xdg-open &> /dev/null; then
     xdg-open "http://localhost:8000/main.html" &
 fi
 
-# Start Python web server (this blocks)
-python3 -m http.server 8000
+# Start Writingway web server (static files + local backup API)
+python3 main.py --host 127.0.0.1 --port 8000 --backup-dir "$BACKUP_DIR"
 
 # Cleanup when Python server stops
 echo ""


### PR DESCRIPTION
## Summary

  This PR extends the backup system from GitHub-only to a dual-provider model (GitHub + local filesystem), introduces a minimal extensible Python web server, and makes local backup the default option in the UI.

  The goal is to provide reliable backups without requiring external credentials, while keeping GitHub backup fully supported.

  ## Why

  Current behavior required GitHub token setup for practical backup usage. That is a friction point for local/offline usage and quick-start scenarios, as well as for privacy-first situations. This change enables immediate backups to disk and keeps cloud backup as an optional mode.

  ## What Changed

  ### 1. New local web server with backup APIs

  - Added main.py as a custom http.server-based server.
  - Serves static app files and adds API endpoints:
  - POST /api/backups to create a backup file.
  - GET /api/backups?projectId=<id> to list backups for a project.
  - GET /api/backups/<backup_id> to fetch backup payload for restore.
  - Supports configurable backup directory via --backup-dir.
  - Default local backup directory is now ./local_backups.

  ### 2. Backup provider architecture (GitHub + Local)

  - Extended src/modules/github-backup.js to support local backup operations:
  - backupToLocal()
  - listLocalBackups()
  - restoreFromLocalBackup()
  - Existing GitHub flow remains intact:
  - backupToGist()
  - listBackups()
  - restoreFromBackup()
  - Added strict provider normalization so only explicit github mode requires token checks.
  - Added backward-compatible settings load behavior for existing users without a stored provider field.

  ### 3. UI and app logic updates

  - Updated backup panel in main.html:
  - Renamed menu entry to 💾 Backups.
  - Added provider selector (Local / GitHub).
  - Local is shown first and is the default mode.
  - GitHub token field is shown only in GitHub mode.
  - Restore button enable/disable logic is provider-aware.
  - Backup warning banner is provider-aware.
  - Updated backup action methods in src/app.js:
  - Manual backup, auto-backup settings, restore list, and restore action all branch by provider.
  - Local mode no longer prompts for GitHub token.

  ### 4. Startup script integration

  - Updated start.sh and start.bat to run main.py instead of python -m http.server.
  - Added optional startup argument passthrough for backup directory:
  - ./start.sh ./my_backups
  - start.bat my_backups
  - Server prints active backup directory at startup.

  ### 5. Docs and repo hygiene

  - Updated BACKUP_FEATURE.md to document local mode, provider selection, and startup options.
  - Added local_backups/ to .gitignore to avoid committing runtime backup files.

  ## Backward Compatibility

  - Existing users with prior GitHub backup settings continue to work.
  - If old saved settings have no explicit provider but include token/gist metadata, provider auto-resolves to GitHub.
  - Otherwise provider defaults to Local.
