### PR TITLE
feat: make server ports configurable via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Writingway 2 — Custom Port Configuration
+# Copy this file to .env and change values as needed.
+# The launcher scripts source .env automatically.
+
+WRITINGWAY_PORT=8000
+WRITINGWAY_UPDATER_PORT=8001
+WRITINGWAY_AI_PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ node_modules/
 projects/
 project-backups/
 REFACTORING.md
+# Local user config (ports, secrets, etc.)
+.env

--- a/README.md
+++ b/README.md
@@ -122,6 +122,37 @@ The launchers do a few important things for you:
 
 Use the launcher scripts instead of opening `main.html` directly.
 
+## Custom Port Configuration
+
+By default the app server, updater service, and AI server bind to `127.0.0.1` on ports 8000, 8001, and 8080 respectively. These ports are configurable through environment variables so that Writingway can run alongside other local services.
+
+Set the following environment variables before starting the launcher:
+
+| Variable | Default | Service |
+|---|---|---|
+| `WRITINGWAY_PORT` | `8000` | App server (web UI) |
+| `WRITINGWAY_UPDATER_PORT` | `8001` | Update checker service |
+| `WRITINGWAY_AI_PORT` | `8080` | llama.cpp AI server |
+
+### Using a .env file
+
+Create a `.env` file in the project root (or copy from `.env.example`):
+
+```bash
+cp .env.example .env
+```
+
+Edit the values, then run the launcher as usual. The launcher scripts source `.env` automatically.
+
+These variables are also available for direct export:
+
+```bash
+export WRITINGWAY_PORT=9000
+export WRITINGWAY_UPDATER_PORT=9001
+export WRITINGWAY_AI_PORT=9080
+./start.sh   # or start.bat on Windows
+```
+
 ## Saving and backups
 
 ### Manual project save

--- a/main.html
+++ b/main.html
@@ -34,6 +34,7 @@
     <script defer src="src/template-loader.js"></script>
     <script defer src="src/workshop.js"></script>
     <script defer src="src/modules/workshop.js"></script>
+    <script defer src="src/config.js"></script>
     <script defer src="src/update-checker.js"></script>
     <script defer src="src/tts.js"></script>
     <script defer src="src/w1-importer.js"></script>
@@ -1498,11 +1499,13 @@
                         <label
                             style="display:block;font-size:13px;font-weight:600;margin-bottom:6px;color:var(--text-primary);">Server
                             URL</label>
-                        <input type="text" x-model="aiEndpoint" value="http://localhost:8080"
+                        <input type="text" x-model="aiEndpoint" value=""
+                            x-init="if (!aiEndpoint) aiEndpoint = 'http://localhost:' + (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.aiPort ? window.WritingwayConfig.aiPort : 8080)"
                             placeholder="http://localhost:8080"
                             style="width:100%;padding:8px;border:1px solid var(--border);background:var(--bg-secondary);color:var(--text-primary);border-radius:6px;">
-                        <p style="font-size:11px;color:var(--text-secondary);margin:4px 0 0 0;">The llama-server
-                            endpoint (usually localhost:8080)</p>
+                        <p class="text-xs text-zinc-500 mt-1" style="font-size:11px;color:var(--text-secondary);margin:4px 0 0 0;"
+                           x-text="'The llama-server endpoint (usually localhost:' + (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.aiPort ? window.WritingwayConfig.aiPort : 8080) + ')'"
+                        >The llama-server endpoint (usually localhost:8080)</p>
                     </div>
                 </div>
 

--- a/src/ai.js
+++ b/src/ai.js
@@ -52,7 +52,9 @@
                 app.loadingMessage = 'Connecting to local AI server...';
                 app.loadingProgress = 30;
 
-                const endpoint = app.aiEndpoint || 'http://localhost:8080';
+                const defaultAIPort = (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.aiPort)
+                    ? window.WritingwayConfig.aiPort : 8080;
+                const endpoint = app.aiEndpoint || 'http://localhost:' + defaultAIPort;
                 const response = await fetch(endpoint + '/health', {
                     method: 'GET',
                     signal: AbortSignal.timeout(3000) // 3 second timeout

--- a/src/app.js
+++ b/src/app.js
@@ -83,6 +83,10 @@ document.addEventListener('alpine:init', () => {
             async init() {
                 this.updateLoadingScreen(10, 'Initializing...', 'Checking startup method...');
 
+                // Read the configured app port for use in the loading screen
+                var _wwPort = (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.port)
+                    ? window.WritingwayConfig.port : 8000;
+
                 // Detect if opened via file:// protocol and warn user
                 if (window.location.protocol === 'file:') {
                     const useFileDirect = confirm(
@@ -111,7 +115,7 @@ document.addEventListener('alpine:init', () => {
                                     <p style="margin:0;font-size:14px;"><strong>Why?</strong></p>
                                     <p style="margin:8px 0 0 0;font-size:13px;line-height:1.6;">
                                         start.bat ensures:<br>
-                                        • Unified project database (http://localhost:8000)<br>
+                                        • Unified project database (http://localhost:${_wwPort})<br>
                                         • Local AI server running with GPU support<br>
                                         • Fast model loading (2-3 seconds vs minutes)<br>
                                         • Proper CORS and security settings

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,26 @@
+// Writingway config fetcher
+// Fetches /writingway.json from the local app server and makes
+// port values available globally. Silently fails and falls back
+// to hardcoded defaults on any error.
+(function () {
+    var config = {
+        port: 8000,
+        updaterPort: 8001,
+        aiPort: 8080
+    };
+
+    function load() {
+        fetch('/writingway.json')
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (data.port != null) config.port = data.port;
+                if (data.updaterPort != null) config.updaterPort = data.updaterPort;
+                if (data.aiPort != null) config.aiPort = data.aiPort;
+            })
+            .catch(function () { /* silently fallback to defaults */ });
+    }
+
+    load();
+
+    window.WritingwayConfig = config;
+})();

--- a/src/generation.js
+++ b/src/generation.js
@@ -111,7 +111,9 @@
         const aiProvider = app?.aiProvider || 'anthropic';
         const aiApiKey = app?.aiApiKey || '';
         const aiModel = app?.aiModel || '';
-        const aiEndpoint = app?.aiEndpoint || 'http://localhost:8080';
+        const defaultAIPort = (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.aiPort)
+            ? window.WritingwayConfig.aiPort : 8080;
+        const aiEndpoint = app?.aiEndpoint || 'http://localhost:' + defaultAIPort;
         const useProviderDefaults = app?.useProviderDefaults || false;
         const temperature = app?.temperature || 0.8;
         const maxTokens = app?.maxTokens || 300;

--- a/src/modules/ai-settings.js
+++ b/src/modules/ai-settings.js
@@ -127,11 +127,13 @@
         async scanLocalModels(app) {
             try {
                 if (app.runtimeInfo && Array.isArray(app.runtimeInfo.ggufModels) && app.runtimeInfo.ggufModels.length > 0) {
-                    const modelList = app.runtimeInfo.ggufModels.join('\n- ');
+                    const defaultAIPort = (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.aiPort)
+                    ? window.WritingwayConfig.aiPort : 8080;
+                const modelList = app.runtimeInfo.ggufModels.join('\n- ');
                     alert('ℹ️ Local GGUF Model Info:\n\n' +
                         'Detected model files:\n- ' + modelList + '\n\n' +
                         'The llama.cpp backend loads the first GGUF file it finds when Writingway starts.\n\n' +
-                        'Connection URL: http://localhost:8080');
+                        'Connection URL: http://localhost:' + defaultAIPort);
                     return;
                 }
 
@@ -150,12 +152,14 @@
          */
         saveGenerationParams(app) {
             try {
+                const defaultAIPort = (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.aiPort)
+                    ? window.WritingwayConfig.aiPort : 8080;
                 const settings = {
                     mode: app.aiMode,
                     provider: app.aiProvider,
                     apiKey: app.aiApiKey,
                     model: app.aiModel,
-                    endpoint: app.aiEndpoint || (app.aiMode === 'local' ? 'http://localhost:8080' : ''),
+                    endpoint: app.aiEndpoint || (app.aiMode === 'local' ? 'http://localhost:' + defaultAIPort : ''),
                     temperature: app.temperature,
                     maxTokens: app.maxTokens,
                     useProviderDefaults: app.useProviderDefaults || false,
@@ -178,12 +182,14 @@
                 }
 
                 // Save settings to localStorage
+                const defaultAIPort = (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.aiPort)
+                    ? window.WritingwayConfig.aiPort : 8080;
                 const settings = {
                     mode: app.aiMode,
                     provider: app.aiProvider,
                     apiKey: app.aiApiKey,
                     model: app.aiModel,
-                    endpoint: app.aiEndpoint || (app.aiMode === 'local' ? 'http://localhost:8080' : ''),
+                    endpoint: app.aiEndpoint || (app.aiMode === 'local' ? 'http://localhost:' + defaultAIPort : ''),
                     temperature: app.temperature,
                     maxTokens: app.maxTokens,
                     useProviderDefaults: app.useProviderDefaults || false,
@@ -198,7 +204,9 @@
 
                 if (app.aiMode === 'local') {
                     // Test local server with retry logic for model loading
-                    const endpoint = app.aiEndpoint || 'http://localhost:8080';
+                    const defaultAIPort2 = (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.aiPort)
+                        ? window.WritingwayConfig.aiPort : 8080;
+                    const endpoint = app.aiEndpoint || 'http://localhost:' + defaultAIPort2;
                     const maxRetries = 60; // Try for up to ~3 minutes (60 * 3s) - large models can take time
                     const retryDelay = 3000; // 3 seconds between retries
                     let attempt = 0;

--- a/src/update-checker.js
+++ b/src/update-checker.js
@@ -12,7 +12,8 @@
         repoName: 'Writingway2',
         branch: 'main',
 
-        // Updater service endpoint
+        // updaterUrl is set in config.js; updated here if config is available
+        // (the override happens below at the end of the IIFE)
         updaterUrl: 'http://127.0.0.1:8001',
 
         /**
@@ -201,6 +202,11 @@
             }
         }
     };
+
+    // Override updaterUrl if config is available
+    if (typeof window.WritingwayConfig !== 'undefined' && window.WritingwayConfig.updaterPort) {
+        UpdateChecker.updaterUrl = 'http://127.0.0.1:' + window.WritingwayConfig.updaterPort;
+    }
 
     // Export to window
     window.UpdateChecker = UpdateChecker;

--- a/start.bat
+++ b/start.bat
@@ -3,6 +3,21 @@ setlocal enabledelayedexpansion
 title Writingway 2.0
 color 0A
 
+REM ========================================
+REM  Read port configuration from environment
+REM ========================================
+if exist ".env" (
+    PowerShell -NoProfile -Command "$lines = Get-Content '.env' -Encoding UTF8; foreach ($line in $lines) { if ($line -match '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$') { [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2], 'Process') } }" 2>nul
+    echo [*] Loaded .env
+    echo.
+)
+set "APP_PORT=%WRITINGWAY_PORT%"
+if "!APP_PORT!"=="" set "APP_PORT=8000"
+set "UPDATER_PORT=%WRITINGWAY_UPDATER_PORT%"
+if "!UPDATER_PORT!"=="" set "UPDATER_PORT=8001"
+set "AI_PORT=%WRITINGWAY_AI_PORT%"
+if "!AI_PORT!"=="" set "AI_PORT=8080"
+
 echo.
 echo ================================
 echo   Starting Writingway 2.0...
@@ -168,9 +183,9 @@ echo.
 
 REM Start llama.cpp server in background (keep window open with /k)
 REM Using -c 0 to automatically use the model's maximum context size
-start "Writingway AI Server" cmd /k "llama\llama-server.exe -m "!MODEL_PATH!" -c 0 -ngl 999 --port 8080 --host 127.0.0.1"
+start "Writingway AI Server" cmd /k "llama\llama-server.exe -m "!MODEL_PATH!" -c 0 -ngl 999 --port !AI_PORT! --host 127.0.0.1"
 
-echo [*] AI server starting on port 8080...
+echo [*] AI server starting on port !AI_PORT!...
 echo [*] Waiting for AI server to initialize...
 
 REM Wait for llama server to be ready (check every second, max 30 seconds)
@@ -180,7 +195,7 @@ timeout /t 1 /nobreak >nul
 set /a counter+=1
 
 REM Try to connect to the server
-curl -s http://localhost:8080/health >nul 2>&1
+curl -s http://localhost:!AI_PORT!/health >nul 2>&1
 if %errorlevel% equ 0 (
     echo [OK] AI server is ready!
     goto start_web
@@ -204,7 +219,7 @@ echo.
 
 REM Start the updater server in background (minimized)
 start /min "Writingway Updater" cmd /c "python tools\updater-server.py"
-echo [OK] Updater service started on port 8001
+echo [OK] Updater service started on port !UPDATER_PORT!
 echo.
 
 echo ================================
@@ -213,7 +228,7 @@ echo ================================
 echo.
 
 REM Start Python HTTP server and open browser
-echo [*] Starting app server on port 8000...
+echo [*] Starting app server on port !APP_PORT!...
 echo [*] Opening Writingway in 3 seconds...
 echo.
 echo ================================
@@ -226,9 +241,9 @@ echo  * The page will show a loading screen while AI initializes
 echo  * First startup may take 2-3 minutes for AI to load
 echo  * Keep this window open while using Writingway
 echo.
-echo Web UI: http://localhost:8000/main.html
-echo AI API: http://localhost:8080
-echo Updater: http://localhost:8001
+echo Web UI: http://localhost:!APP_PORT!/main.html
+echo AI API: http://localhost:!AI_PORT!
+echo Updater: http://localhost:!UPDATER_PORT!
 echo.
 
 REM Wait 3 seconds before opening browser (gives servers time to stabilize)
@@ -242,7 +257,7 @@ echo ================================
 echo.
 
 REM Open browser
-start "" http://localhost:8000/main.html
+start "" http://localhost:!APP_PORT!/main.html
 
 REM Start Writingway app server (blocks here)
 python tools\writingway-server.py

--- a/start.sh
+++ b/start.sh
@@ -24,6 +24,18 @@ fi
 echo "[OK] Python 3 found"
 echo ""
 
+# Load environment defaults from .env file if present
+if [ -f ".env" ]; then
+    set -a; . ./.env; set +a
+    echo "[*] Loaded .env"
+    echo ""
+fi
+
+# Port configuration (defaults)
+APP_PORT="${WRITINGWAY_PORT:-8000}"
+UPDATER_PORT="${WRITINGWAY_UPDATER_PORT:-8001}"
+AI_PORT="${WRITINGWAY_AI_PORT:-8080}"
+
 if [ -f ".update/ready.json" ]; then
     echo "[*] Staged update detected! Applying update..."
     echo ""
@@ -164,10 +176,10 @@ if [ $SKIP_MODEL -eq 0 ]; then
     # For Mac: Use Metal GPU acceleration (-ngl 999)
     # For Linux: Use CUDA if available, otherwise CPU
     # Using -c 0 to automatically use the model's maximum context size
-    ./llama/llama-server -m "$MODEL_PATH" -c 0 -ngl 999 --port 8080 --host 127.0.0.1 > llama-server.log 2>&1 &
+    ./llama/llama-server -m "$MODEL_PATH" -c 0 -ngl 999 --port "$AI_PORT" --host 127.0.0.1 > llama-server.log 2>&1 &
     LLAMA_PID=$!
     
-    echo "[*] AI server starting on port 8080 (PID: $LLAMA_PID)..."
+    echo "[*] AI server starting on port $AI_PORT (PID: $LLAMA_PID)..."
     echo "[*] Waiting for AI server to initialize..."
     
     # Wait for llama-server to be ready (max 30 seconds)
@@ -177,7 +189,7 @@ if [ $SKIP_MODEL -eq 0 ]; then
         counter=$((counter + 1))
         
         # Try to connect to the server
-        if curl -s http://localhost:8080/health > /dev/null 2>&1; then
+        if curl -s "http://localhost:$AI_PORT/health" > /dev/null 2>&1; then
             echo "[OK] AI server is ready!"
             break
         fi
@@ -203,7 +215,7 @@ echo ""
 
 python3 tools/updater-server.py > updater-server.log 2>&1 &
 UPDATER_PID=$!
-echo "[OK] Updater service started on port 8001"
+echo "[OK] Updater service started on port $UPDATER_PORT"
 echo ""
 
 echo "================================"
@@ -211,7 +223,7 @@ echo "   Starting Web Server..."
 echo "================================"
 echo ""
 
-echo "[*] Starting app server on port 8000..."
+echo "[*] Starting app server on port $APP_PORT..."
 echo "[*] Opening Writingway once the app server is ready..."
 echo ""
 echo "================================"
@@ -224,9 +236,9 @@ echo "  * The page will show a loading screen while AI initializes"
 echo "  * First startup may take 2-3 minutes for AI to load"
 echo "  * Keep this terminal open while using Writingway"
 echo ""
-echo "Web UI: http://localhost:8000/main.html"
-echo "AI API: http://localhost:8080"
-echo "Updater: http://localhost:8001"
+echo "Web UI: http://localhost:$APP_PORT/main.html"
+echo "AI API: http://localhost:$AI_PORT"
+echo "Updater: http://localhost:$UPDATER_PORT"
 echo ""
 
 cleanup() {
@@ -256,7 +268,7 @@ while [ $counter -lt 30 ]; do
     sleep 1
     counter=$((counter + 1))
 
-    if curl -s http://127.0.0.1:8000/api/health > /dev/null 2>&1; then
+    if curl -s "http://127.0.0.1:$APP_PORT/api/health" > /dev/null 2>&1; then
         echo "[OK] App server is ready!"
         break
     fi
@@ -276,10 +288,10 @@ echo ""
 # Open browser (works on Mac and most Linux)
 if command -v open &> /dev/null; then
     # macOS
-    open "http://localhost:8000/main.html"
+    open "http://localhost:$APP_PORT/main.html"
 elif command -v xdg-open &> /dev/null; then
     # Linux
-    xdg-open "http://localhost:8000/main.html" &
+    xdg-open "http://localhost:$APP_PORT/main.html" &
 fi
 
 wait "$WEB_PID"

--- a/tests/t7_dynamic_port.js
+++ b/tests/t7_dynamic_port.js
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+/**
+ * T7 Tests: Dynamic port references in app.js and main.html
+ *
+ * Run: node tests/t7_dynamic_port.js
+ *
+ * Acceptance criteria:
+ *   AC1: src/app.js references configured app port from WritingwayConfig.
+ *   AC2: main.html aiEndpoint input dynamically defaults from config.
+ *   AC3: localStorage user overrides preserved — dynamic default only when no value exists.
+ *   AC4: Direct file:// open of main.html shows fallback port 8080 without errors.
+ *   AC5: No Alpine.js errors in browser console.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const PASS = [];
+const FAIL = [];
+
+function readRelative(rel) {
+    return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+function assert(label, condition, detail) {
+    if (condition) {
+        PASS.push(label);
+        console.log(`  ✓ ${label}`);
+    } else {
+        FAIL.push(label);
+        console.log(`  ✗ ${label}${detail ? ': ' + detail : ''}`);
+    }
+}
+
+function countOccurrences(text, regex) {
+    let matches = text.match(regex);
+    return matches ? matches.length : 0;
+}
+
+function balancedParens(str) {
+    let depth = 0;
+    for (let i = 0; i < str.length; i++) {
+        if (str[i] === '(') depth++;
+        if (str[i] === ')') depth--;
+        if (depth < 0) return false;
+    }
+    return depth === 0;
+}
+
+// Load files
+const appJs = readRelative('src/app.js');
+const mainHtml = readRelative('main.html');
+const configJs = readRelative('src/config.js');
+
+console.log('=== T7: Dynamic Port Config Tests ===\n');
+
+// ── AC1: app.js dynamic port ─────────────────────────────────────
+console.log('AC1 – src/app.js references configured app port');
+
+assert(
+    'Contains var _wwPort definition',
+    /var _wwPort/.test(appJs),
+    'not found'
+);
+assert(
+    'Uses typeof guard for WritingwayConfig',
+    /typeof window\.WritingwayConfig/.test(appJs),
+    'not found'
+);
+assert(
+    'Reads WritingwayConfig.port property',
+    /WritingwayConfig\.port/.test(appJs),
+    'not found'
+);
+assert(
+    'Falls back to 8000 when config missing',
+    /WritingwayConfig\.port\)\s*\?\s*window\.WritingwayConfig\.port\s*\:\s*8000/.test(appJs),
+    'not found'
+);
+assert(
+    'Template literal uses ${_wwPort}',
+    /localhost:\$\{_wwPort\}/.test(appJs),
+    'not found'
+);
+assert(
+    '_wwPort defined before file:// check',
+    appJs.indexOf('// Read the configured app port') < appJs.indexOf("window.location.protocol === 'file:'"),
+    'wrong order'
+);
+{
+    const blockStart = appJs.indexOf('// Detect if opened via file:// protocol');
+    const blockEnd = appJs.indexOf('this.updateLoadingScreen(20', blockStart);
+    const block = blockStart >= 0 ? appJs.slice(blockStart, blockEnd) : '';
+    assert(
+        'No hardcoded localhost:8000 in file-protocol block',
+        block.length > 0 && !/localhost:8000/.test(block),
+        'still has hardcoded 8000'
+    );
+    assert(
+        'File-protocol block uses ${_wwPort}',
+        block.length > 0 && /\$\{_wwPort\}/.test(block),
+        'missing template reference'
+    );
+}
+
+// ── AC2: main.html dynamic aiEndpoint default ────────────────────
+console.log('\nAC2 – main.html aiEndpoint defaults from config');
+
+assert(
+    'Contains x-init with WritingwayConfig',
+    /x-init=[^>]*WritingwayConfig/.test(mainHtml),
+    'not found'
+);
+assert(
+    'x-init assigns to aiEndpoint',
+    /if \(!aiEndpoint\) aiEndpoint/.test(mainHtml),
+    'not found'
+);
+assert(
+    'x-init uses WritingwayConfig.aiPort',
+    /WritingwayConfig\.aiPort/.test(mainHtml),
+    'not found'
+);
+assert(
+    'x-init falls back to 8080',
+    /WritingwayConfig\.aiPort\s*\?\s*window\.WritingwayConfig\.aiPort\s*:\s*8080/.test(mainHtml),
+    'not found'
+);
+assert(
+    'Contains x-text on description paragraph',
+    /x-text=[^>]*WritingwayConfig\.aiPort/.test(mainHtml),
+    'not found'
+);
+assert(
+    'x-text falls back to 8080',
+    /x-text=[^>]*: 8080/.test(mainHtml),
+    'not found'
+);
+assert(
+    'Hardcoded value="http://localhost:8080" removed',
+    !/value="http:\/\/localhost:8080"/.test(mainHtml),
+    'still present'
+);
+assert(
+    'Placeholder still shows localhost:8080',
+    /placeholder="http:\/\/localhost:8080"/.test(mainHtml),
+    'not found'
+);
+assert(
+    'x-model="aiEndpoint" on input',
+    /x-model="aiEndpoint"/.test(mainHtml),
+    'not found'
+);
+
+// ── AC3: localStorage overrides preserved ────────────────────────
+console.log('\nAC3 – localStorage user overrides preserved');
+
+assert(
+    'x-init guards with !aiEndpoint (not unconditional)',
+    /x-init="if \(!aiEndpoint\)/.test(mainHtml),
+    'not found'
+);
+assert(
+    'main.html 8080 fallback when config unavailable',
+    /WritingwayConfig\.aiPort\s*\?\s*window\.WritingwayConfig\.aiPort\s*:\s*8080/.test(mainHtml),
+    'not found'
+);
+assert(
+    'app.js 8000 fallback when config unavailable',
+    /WritingwayConfig\.port\)\s*\?\s*window\.WritingwayConfig\.port\s*\:\s*8000/.test(appJs),
+    'not found'
+);
+
+// ── AC4: file:// fallback shows 8080 without errors ──────────────
+console.log('\nAC4 – file:// fallback port 8080 without errors');
+
+assert(
+    'main.html has typeof guard for WritingwayConfig',
+    /typeof window\.WritingwayConfig/.test(mainHtml),
+    'not found'
+);
+assert(
+    'app.js has typeof guard for WritingwayConfig',
+    /typeof window\.WritingwayConfig/.test(appJs),
+    'not found'
+);
+assert(
+    'placeholder includes localhost:8080 for visual consistency',
+    /localhost:8080/.test(mainHtml),
+    'not found'
+);
+
+// ── AC5: No Alpine.js errors in browser console ──────────────────
+console.log('\nAC5 – Alpine.js x-init syntax is valid');
+
+// Find the specific x-init on the aiEndpoint input (line ~1503 context)
+const aiEndpointSection = mainHtml.match(/aiEndpoint.*?x-init="([^"]*)"/s);
+const xInitMatch = aiEndpointSection ? { _0: 'x-init="' + aiEndpointSection[1] + '"', 1: aiEndpointSection[1] } : null;
+assert(
+    'x-init attribute exists on aiEndpoint input and is parseable',
+    xInitMatch !== null && xInitMatch[1].length > 0,
+    'not found or empty'
+);
+if (xInitMatch) {
+    const xInitExpr = xInitMatch[1];
+    assert(
+        'x-init expression has balanced parentheses',
+        balancedParens(xInitExpr),
+        'unbalanced parens'
+    );
+    assert(
+        'x-init expression starts with if',
+        xInitExpr.trim().startsWith('if'),
+        'starts with: ' + xInitExpr.trim().slice(0, 30)
+    );
+    assert(
+        'x-init assigns to aiEndpoint',
+        xInitExpr.includes('aiEndpoint'),
+        'not found'
+    );
+}
+
+const xTextMatches = mainHtml.match(/x-text="([^"]*)"/g);
+assert(
+    'x-text attribute exists and is parseable',
+    xTextMatches !== null && xTextMatches.length > 0,
+    'not found'
+);
+if (xTextMatches) {
+    let allBalanced = true;
+    for (const m of xTextMatches) {
+        const inner = m.match(/x-text="([^"]*)"/);
+        if (inner && !balancedParens(inner[1])) {
+            allBalanced = false;
+            break;
+        }
+    }
+    assert(
+        'All x-text expressions have balanced parentheses',
+        allBalanced,
+        'unbalanced'
+    );
+}
+
+assert(
+    'Alpine.js loaded in document',
+    /alpine\.min\.js/.test(mainHtml),
+    'not found'
+);
+assert(
+    'x-data="app" on root element',
+    /x-data="app"/.test(mainHtml),
+    'not found'
+);
+
+// ── Integration: config.js ────────────────────────────────────────
+console.log('\nIntegration – config.js WritingwayConfig shape');
+
+assert(
+    'config.js exposes window.WritingwayConfig',
+    /window\.WritingwayConfig/.test(configJs),
+    'not found'
+);
+assert(
+    'config.js defines port default 8000',
+    /port:\s*8000/.test(configJs),
+    'not found'
+);
+assert(
+    'config.js defines aiPort default 8080',
+    /aiPort:\s*8080/.test(configJs),
+    'not found'
+);
+assert(
+    'config.js defines updaterPort default 8001',
+    /updaterPort:\s*8001/.test(configJs),
+    'not found'
+);
+assert(
+    'config.js silently catches fetch errors',
+    /\.catch\s*\(/.test(configJs),
+    'not found'
+);
+
+// ── Summary ──────────────────────────────────────────────────────
+console.log('\n=== Results ===');
+console.log(`Passed: ${PASS.length}`);
+console.log(`Failed: ${FAIL.length}`);
+
+if (FAIL.length > 0) {
+    console.log('\nFailures:');
+    FAIL.forEach(f => console.log(`  - ${f}`));
+    process.exit(1);
+} else {
+    console.log('\nAll T7 acceptance criteria verified ✓');
+    process.exit(0);
+}

--- a/tests/test_custom_port_config.py
+++ b/tests/test_custom_port_config.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Tests for .env.example creation and README.md Custom Port Configuration section."""
+
+import os
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestEnvExampleExists(unittest.TestCase):
+    """AC1: .env.example exists in the project root."""
+
+    def test_env_example_file_exists(self):
+        """The .env.example file must exist at project root."""
+        f = ROOT / ".env.example"
+        self.assertTrue(f.exists(), ".env.example not found in project root")
+        self.assertTrue(f.is_file(), ".env.example is not a regular file")
+
+
+class TestEnvExampleContent(unittest.TestCase):
+    """AC1: .env.example contains three variable assignments with default values."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.content = (ROOT / ".env.example").read_text()
+        # Collect non-comment, non-blank lines (actual assignments)
+        cls.assignments = [
+            line.strip()
+            for line in cls.content.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+
+    def test_three_assignments(self):
+        """There are exactly three variable assignment lines."""
+        self.assertEqual(
+            len(self.assignments),
+            3,
+            f"Expected 3 assignments, found {len(self.assignments)}: {self.assignments}",
+        )
+
+    def test_writingway_port(self):
+        """WRITINGWAY_PORT = 8000 is present."""
+        self.assertIn("WRITINGWAY_PORT=8000", "\n".join(self.assignments))
+
+    def test_writingway_updater_port(self):
+        """WRITINGWAY_UPDATER_PORT = 8001 is present."""
+        self.assertIn("WRITINGWAY_UPDATER_PORT=8001", "\n".join(self.assignments))
+
+    def test_writingway_ai_port(self):
+        """WRITINGWAY_AI_PORT = 8080 is present."""
+        self.assertIn("WRITINGWAY_AI_PORT=8080", "\n".join(self.assignments))
+
+    def test_no_json_format(self):
+        """Must not use JSON format (no curly braces, no key-value objects)."""
+        self.assertNotIn("{", self.content, ".env.example uses JSON format instead of plain assignments")
+        self.assertNotIn("}", self.content, ".env.example uses JSON format instead of plain assignments")
+
+
+class TestReadmeCustomPortSection(unittest.TestCase):
+    """AC2: README.md has a 'Custom Port Configuration' section with required content."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.content = (ROOT / "README.md").read_text()
+
+    def test_section_heading_exists(self):
+        """README contains '## Custom Port Configuration' heading."""
+        self.assertIn("## Custom Port Configuration", self.content)
+
+    def test_table_present(self):
+        """A markdown table with Variable, Default, Service columns is present."""
+        self.assertIn("| Variable | Default | Service |", self.content)
+        self.assertIn("|---|---|---|", self.content)
+
+    def test_table_variable_rows(self):
+        """All three variable rows appear in the table."""
+        self.assertIn("| `WRITINGWAY_PORT` | `8000` | App server (web UI) |", self.content)
+        self.assertIn("| `WRITINGWAY_UPDATER_PORT` | `8001` | Update checker service |", self.content)
+        self.assertIn("| `WRITINGWAY_AI_PORT` | `8080` | llama.cpp AI server |", self.content)
+
+    def test_dotenv_usage_example(self):
+        """The section contains a .env usage example (cp .env.example .env)."""
+        self.assertIn("cp .env.example .env", self.content)
+
+    def test_shell_export_examples(self):
+        """The section contains export examples."""
+        self.assertIn("export WRITINGWAY_PORT=9000", self.content)
+        self.assertIn("export WRITINGWAY_UPDATER_PORT=9001", self.content)
+        self.assertIn("export WRITINGWAY_AI_PORT=9080", self.content)
+
+    def test_section_is_between_launchers_and_saving(self):
+        """Custom Port Configuration is placed between 'Launchers and local services' and 'Saving and backups'."""
+        launchers_pos = self.content.index("## Launchers and local services")
+        custom_pos = self.content.index("## Custom Port Configuration")
+        saving_pos = self.content.index("## Saving and backups")
+
+        self.assertLess(
+            launchers_pos,
+            custom_pos,
+            "Custom Port Configuration must come after 'Launchers and local services'",
+        )
+        self.assertLess(
+            custom_pos,
+            saving_pos,
+            "Custom Port Configuration must come before 'Saving and backups'",
+        )
+
+
+class TestReadmeNoContentRemoved(unittest.TestCase):
+    """AC3: No existing README content was removed or altered except the new section insertion."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.content = (ROOT / "README.md").read_text()
+
+    def _content(self):
+        return type(self).content
+
+    def test_section_headers_preserved(self):
+        """All original section headers are still present."""
+        expected_headers = [
+            "## What Writingway does",
+            "## Highlights",
+            "## Requirements",
+            "## Quick start",
+            "## First-run local AI flow",
+            "## AI modes",
+            "## Launchers and local services",
+            "## Saving and backups",
+            "## Updates",
+            "## Writingway 1 import",
+            "## Project structure",
+            "## Development notes",
+            "## Current status",
+            "## Troubleshooting",
+        ]
+        for header in expected_headers:
+            self.assertIn(
+                header,
+                self._content(),
+                f"Section header '{header}' was removed or altered",
+            )
+
+    def test_launcher_service_lines_unchanged(self):
+        """The specific launcher service description lines are intact."""
+        c = self._content()
+        self.assertIn("- Start the Writingway app server on `http://127.0.0.1:8000`", c)
+        self.assertIn("- Start the updater service on `http://127.0.0.1:8001`", c)
+        self.assertIn("- Start llama.cpp on `http://127.0.0.1:8080` when local GGUF mode is available", c)
+        self.assertIn("Use the launcher scripts instead of opening `main.html` directly.", c)
+
+    def test_saving_and_backups_content_unchanged(self):
+        """The Saving and backups section content is intact."""
+        c = self._content()
+        self.assertIn("### Manual project save", c)
+        self.assertIn("### Local versioning backup", c)
+        self.assertIn("### GitHub Gist backup", c)
+        self.assertIn("project-backups/", c)
+
+    def test_troubleshooting_unchanged(self):
+        """Troubleshooting section is intact."""
+        c = self._content()
+        self.assertIn("### The browser says it cannot connect on startup", c)
+        self.assertIn("The launchers wait for the local app server before opening the browser.", c)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_port_env.py
+++ b/tests/test_port_env.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Tests for environment-variable config and /writingway.json endpoint."""
+
+import importlib.util
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import unittest
+from http.client import HTTPConnection
+from pathlib import Path
+
+SERVER_DIR = Path(__file__).resolve().parent.parent / "tools"
+
+# Pre-cleanup any lingering servers on default ports that might block tests
+def _cleanup_default_ports():
+    """Kill any processes bound to the default ports used by these tests."""
+    for p in [8000, 8001, 8080]:
+        try:
+            subprocess.run(
+                ["lsof", "-ti", f":{p}"],
+                capture_output=True, text=True, timeout=3,
+            )
+        except Exception:
+            pass
+
+
+def _free_port() -> int:
+    """Return a currently-free TCP port."""
+    import socket as _sock
+    s = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _load_port_from_file(filename: str, env: dict) -> int:
+    """Dynamically load PORT from *filename* without running main()."""
+    spec = importlib.util.spec_from_file_location(
+        "writingway_test_module", str(SERVER_DIR / filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["writingway_test_module"] = mod  # required for loader
+    # Set env vars before exec
+    saved = {}
+    for k, v in env.items():
+        saved[k] = os.environ.get(k)
+    for k, v in env.items():
+        os.environ[k] = v
+    try:
+        spec.loader.exec_module(mod)
+        return int(mod.PORT)
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        sys.modules.pop("writingway_test_module", None)
+
+
+def _make_request(port: int, path: str = "/writingway.json") -> tuple[int, dict, str]:
+    """GET *path* on localhost:*port*, return (status, json_body, content_type)."""
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        body_bytes = resp.read()
+        content_type = resp.getheader("Content-Type", "")
+        status = resp.status
+    finally:
+        conn.close()
+    json_body = json.loads(body_bytes.decode("utf-8"))
+    return status, json_body, content_type
+
+
+def _start_server(port: int, extra_env: dict | None = None) -> subprocess.Popen:
+    """Start the writingway server on *port* in a subprocess."""
+    server_env = os.environ.copy()
+    server_env["WRITINGWAY_PORT"] = str(port)
+    if extra_env:
+        server_env.update(extra_env)
+    proc = subprocess.Popen(
+        [sys.executable, "-u", str(SERVER_DIR / "writingway-server.py")],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, env=server_env,
+    )
+    time.sleep(0.8)
+    return proc
+
+
+def _stop_server(proc: subprocess.Popen) -> None:
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        # Give OS time to release the port
+        time.sleep(0.2)
+
+
+class TestPortEnvVars(unittest.TestCase):
+    """Verify that each server reads its port from an environment variable."""
+
+    def test_writingway_server_default_port(self):
+        """When WRITINGWAY_PORT is unset, default is 8000."""
+        port = _load_port_from_file("writingway-server.py", {})
+        self.assertEqual(port, 8000)
+
+    def test_writingway_server_custom_port(self):
+        """When WRITINGWAY_PORT is set, PORT reflects it."""
+        port = _load_port_from_file("writingway-server.py", {"WRITINGWAY_PORT": "9191"})
+        self.assertEqual(port, 9191)
+
+    def test_updater_server_default_port(self):
+        """When WRITINGWAY_UPDATER_PORT is unset, default is 8001."""
+        port = _load_port_from_file("updater-server.py", {})
+        self.assertEqual(port, 8001)
+
+    def test_updater_server_custom_port(self):
+        """When WRITINGWAY_UPDATER_PORT is set, PORT reflects it."""
+        port = _load_port_from_file("updater-server.py", {"WRITINGWAY_UPDATER_PORT": "8181"})
+        self.assertEqual(port, 8181)
+
+
+class TestWritingwayJSONEndpoint(unittest.TestCase):
+    """Test the GET /writingway.json endpoint."""
+
+    def test_writingway_json_default_ports(self):
+        """Default /writingway.json returns correct ports."""
+        port = _free_port()
+        proc = _start_server(port)
+        try:
+            status, body, _ = _make_request(port, "/writingway.json")
+            self.assertEqual(status, 200)
+            self.assertEqual(body["port"], port)
+            self.assertEqual(body["updaterPort"], 8001)
+            self.assertEqual(body["aiPort"], 8080)
+        finally:
+            _stop_server(proc)
+
+    def test_writingway_json_content_type(self):
+        """Content-Type is application/json; charset=utf-8."""
+        port = _free_port()
+        proc = _start_server(port)
+        try:
+            _, _, ctype = _make_request(port, "/writingway.json")
+            self.assertIn("application/json", ctype)
+            self.assertIn("charset=utf-8", ctype)
+        finally:
+            _stop_server(proc)
+
+    def test_writingway_json_custom_all_ports(self):
+        """When other env vars are set, all three values are reflected."""
+        port = _free_port()
+        extra = {
+            "WRITINGWAY_UPDATER_PORT": "7001",
+            "WRITINGWAY_AI_PORT": "7080",
+        }
+        proc = _start_server(port, extra)
+        try:
+            status, body, _ = _make_request(port, "/writingway.json")
+            self.assertEqual(status, 200)
+            self.assertEqual(body["port"], port)
+            self.assertEqual(body["updaterPort"], 7001)
+            self.assertEqual(body["aiPort"], 7080)
+        finally:
+            _stop_server(proc)
+
+
+class TestStartupMessages(unittest.TestCase):
+    """Verify startup print statements reflect the resolved port."""
+
+    def _start_and_read_stdout(self, env: dict, server_script: str) -> str:
+        """Start server, wait for startup message, then terminate and return stdout."""
+        proc = subprocess.Popen(
+            [sys.executable, "-u", str(SERVER_DIR / server_script)],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, env=dict(env),
+        )
+        # Wait for startup message to print, then terminate
+        time.sleep(0.5)
+        _stop_server(proc)
+        return proc.stdout.read()
+
+    def test_writingway_startup_print_default(self):
+        """Startup message shows correct port when no env var set."""
+        port = _free_port()
+        env = os.environ.copy()
+        env.pop("WRITINGWAY_PORT", None)
+        # Set a non-default port so it doesn't conflict with any running server
+        env["WRITINGWAY_PORT"] = str(port)
+        stdout = self._start_and_read_stdout(env, "writingway-server.py")
+        # The env var overrides the default, so the printed port should be our test port
+        self.assertIn(f"http://127.0.0.1:{port}", stdout)
+
+    def test_writingway_startup_print_custom(self):
+        """Startup message shows correct port when env var overrides it."""
+        port = _free_port()
+        env = {"WRITINGWAY_PORT": str(port)}
+        stdout = self._start_and_read_stdout(env, "writingway-server.py")
+        self.assertIn(f"http://127.0.0.1:{port}", stdout)
+
+    def test_updater_startup_print_default(self):
+        """Updater prints correct port on startup when no env var set."""
+        env = os.environ.copy()
+        env.pop("WRITINGWAY_UPDATER_PORT", None)
+        stdout = self._start_and_read_stdout(env, "updater-server.py")
+        self.assertIn("http://127.0.0.1:8001", stdout)
+
+    def test_updater_startup_print_custom(self):
+        """Updater prints correct port when env var overrides it."""
+        env = {"WRITINGWAY_UPDATER_PORT": "9999"}
+        stdout = self._start_and_read_stdout(env, "updater-server.py")
+        self.assertIn("http://127.0.0.1:9999", stdout)
+
+    def test_updater_startup_print_custom_env(self):
+        """Updater prints correct port when WRITINGWAY_UPDATER_PORT is set."""
+        env = {"WRITINGWAY_UPDATER_PORT": "5555"}
+        stdout = self._start_and_read_stdout(env, "updater-server.py")
+        self.assertIn("http://127.0.0.1:5555", stdout)
+
+
+class TestBackwardsCompatibility(unittest.TestCase):
+    """Default behavior must produce identical output to current hardcoded values."""
+
+    def test_default_port_unchanged(self):
+        """Default port is still 8000 — no breaking change."""
+        port = _load_port_from_file("writingway-server.py", {})
+        self.assertEqual(port, 8000)
+
+    def test_default_updater_port_unchanged(self):
+        """Default updater port is still 8001 — no breaking change."""
+        port = _load_port_from_file("updater-server.py", {})
+        self.assertEqual(port, 8001)
+
+
+class TestWritingwayJSONNoEnvVars(unittest.TestCase):
+    """When no env vars are set, everything uses defaults."""
+
+    def test_default_ports_no_env(self):
+        """With zero env vars, /writingway.json returns 8000, 8001, 8080."""
+        port = _free_port()
+        env = os.environ.copy()
+        env.pop("WRITINGWAY_PORT", None)
+        env.pop("WRITINGWAY_UPDATER_PORT", None)
+        env.pop("WRITINGWAY_AI_PORT", None)
+        # Set WRITINGWAY_PORT just so the server can start on our test port
+        env["WRITINGWAY_PORT"] = str(port)
+        proc = subprocess.Popen(
+            [sys.executable, "-u", str(SERVER_DIR / "writingway-server.py")],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, env=env,
+        )
+        time.sleep(0.8)
+        try:
+            status, body, _ = _make_request(port, "/writingway.json")
+            self.assertEqual(status, 200)
+            self.assertEqual(body["port"], port)
+            self.assertEqual(body["updaterPort"], 8001)
+            self.assertEqual(body["aiPort"], 8080)
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_start_bat.py
+++ b/tests/test_start_bat.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Tests for start.bat port environment variable support.
+
+Verifies that start.bat:
+  - Defines APP_PORT, UPDATER_PORT, AI_PORT from WRITINGWAY_* env vars
+  - Defaults to 8000, 8001, 8080 when env vars are unset
+  - Uses !VAR! syntax (not %VAR%) for all runtime port references
+  - Replaces every hardcoded port in status messages, curl calls, and browser-open
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+BATCH_PATH = Path(__file__).resolve().parent.parent / "start.bat"
+
+
+class TestPortVariableDefinitions(unittest.TestCase):
+    """Acceptance-criterion: env vars are read and default values set."""
+
+    def test_app_port_defined_from_env(self):
+        """APP_PORT reads from %WRITINGWAY_PORT%."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('set "APP_PORT=%WRITINGWAY_PORT%"', text)
+
+    def test_updater_port_defined_from_env(self):
+        """UPDATER_PORT reads from %WRITINGWAY_UPDATER_PORT%."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('set "UPDATER_PORT=%WRITINGWAY_UPDATER_PORT%"', text)
+
+    def test_ai_port_defined_from_env(self):
+        """AI_PORT reads from %WRITINGWAY_AI_PORT%."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('set "AI_PORT=%WRITINGWAY_AI_PORT%"', text)
+
+    def test_default_app_port(self):
+        """Default APP_PORT is 8000."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('set "APP_PORT=8000"', text)
+
+    def test_default_updater_port(self):
+        """Default UPDATER_PORT is 8001."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('set "UPDATER_PORT=8001"', text)
+
+    def test_default_ai_port(self):
+        """Default AI_PORT is 8080."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('set "AI_PORT=8080"', text)
+
+    def test_default_emptiness_check_app(self):
+        """APP_PORT defaults to 8000 only when the env var is empty (not 8000)."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('if "!APP_PORT!"=="" set "APP_PORT=8000"', text)
+
+    def test_default_emptiness_check_updater(self):
+        text = BATCH_PATH.read_text()
+        self.assertIn('if "!UPDATER_PORT!"=="" set "UPDATER_PORT=8001"', text)
+
+    def test_default_emptiness_check_ai(self):
+        text = BATCH_PATH.read_text()
+        self.assertIn('if "!AI_PORT!"=="" set "AI_PORT=8080"', text)
+
+
+class TestNoHardcodedPortsInRuntimeLines(unittest.TestCase):
+    """Acceptance-criterion: all hardcoded 8000/8001/8080 removed from
+    status messages, curl calls, and browser-open commands."""
+
+    _HARDCODED_RE = re.compile(r"\b(8000|8001|8080)\b")
+
+    def _get_lines(self):
+        text = BATCH_PATH.read_text()
+        return [line.strip() for line in text.splitlines()]
+
+    def _runtime_lines(self):
+        """Lines that should NOT contain hardcoded port numbers.
+
+        We exclude:
+          - Comment lines
+          - The three default-value assignments inside the port-config block
+          - Lines that are only assigning defaults
+        """
+        lines = self._get_lines()
+        result = []
+        in_port_block = False
+        for line in lines:
+            # Detect the port-config block
+            if "Read port configuration from environment" in line:
+                in_port_block = True
+                continue
+            in_port_block = False
+
+            # Skip pure comment lines and empty
+            if not line or line.startswith("REM ") or line.startswith("rem "):
+                result.append(line)  # keep for scanning (will catch false positives)
+
+            # Skip the three default-value assignment lines
+            if line in (
+                'set "APP_PORT=8000"',
+                'set "UPDATER_PORT=8001"',
+                'set "AI_PORT=8080"',
+            ):
+                continue
+            if '"" set "APP_PORT=8000"' in line:
+                continue
+            if '"" set "UPDATER_PORT=8001"' in line:
+                continue
+            if '"" set "AI_PORT=8080"' in line:
+                continue
+
+            result.append(line)
+        return result
+
+    def test_no_hardcoded_8000_in_runtime(self):
+        """No hardcoded 8000 outside default-value lines."""
+        line_text = " ".join(self._runtime_lines())
+        self.assertEqual(
+            list(self._HARDCODED_RE.finditer(line_text)), [],
+            "Found hardcoded 8000 in runtime lines:",
+        )
+
+    def test_no_hardcoded_8001_in_runtime(self):
+        """No hardcoded 8001 outside default-value lines."""
+        line_text = " ".join(self._runtime_lines())
+        self.assertEqual(
+            list(self._HARDCODED_RE.finditer(line_text)), [],
+            "Found hardcoded 8001 in runtime lines:",
+        )
+
+    def test_no_hardcoded_8080_in_runtime(self):
+        """No hardcoded 8080 outside default-value lines."""
+        line_text = " ".join(self._runtime_lines())
+        self.assertEqual(
+            list(self._HARDCODED_RE.finditer(line_text)), [],
+            "Found hardcoded 8080 in runtime lines:",
+        )
+
+
+class TestVariableSyntaxUsed(unittest.TestCase):
+    """Acceptance-criterion: !VAR! syntax is used throughout
+    (matching delayedexpansion on line 2)."""
+
+    def _get_lines(self):
+        return BATCH_PATH.read_text().splitlines()
+
+    def test_ai_port_in_start_command(self):
+        """llama-server starts with --port !AI_PORT!."""
+        lines = self._get_lines()
+        start_line = [
+            l for l in lines if "llama-server.exe" in l and "--port" in l
+        ]
+        self.assertEqual(len(start_line), 1, "Expected exactly one llama start line")
+        self.assertIn("--port !AI_PORT!", start_line[0])
+
+    def test_ai_port_in_health_check(self):
+        """curl health check uses !AI_PORT!."""
+        lines = self._get_lines()
+        curl_line = [l for l in lines if "curl" in l and "health" in l]
+        self.assertEqual(len(curl_line), 1, "Expected exactly one health-check curl")
+        self.assertIn("!AI_PORT!", curl_line[0])
+        self.assertIn("localhost:!AI_PORT!/health", curl_line[0])
+
+    def test_ai_echo_ports_var(self):
+        """AI startup echo uses !AI_PORT!."""
+        lines = self._get_lines()
+        ai_echo = [
+            l for l in lines if "AI server starting on port" in l
+        ]
+        self.assertEqual(len(ai_echo), 1)
+        self.assertIn("!AI_PORT!", ai_echo[0])
+
+    def test_updater_echo_ports_var(self):
+        """Updater echo uses !UPDATER_PORT!."""
+        lines = self._get_lines()
+        up_echo = [
+            l for l in lines if "Updater service started on port" in l
+        ]
+        self.assertEqual(len(up_echo), 1)
+        self.assertIn("!UPDATER_PORT!", up_echo[0])
+
+    def test_app_server_echo_ports_var(self):
+        """App-server echo uses !APP_PORT!."""
+        lines = self._get_lines()
+        echo = [
+            l for l in lines if "Starting app server on port" in l
+        ]
+        self.assertEqual(len(echo), 1)
+        self.assertIn("!APP_PORT!", echo[0])
+
+    def test_web_ui_url_uses_app_port(self):
+        """Web UI message uses !APP_PORT!."""
+        lines = self._get_lines()
+        urls = [
+            l for l in lines if "Web UI:" in l and "http://" in l
+        ]
+        self.assertEqual(len(urls), 1)
+        self.assertIn("!APP_PORT!", urls[0])
+
+    def test_ai_api_url_uses_ai_port(self):
+        """AI API message uses !AI_PORT!."""
+        lines = self._get_lines()
+        urls = [
+            l for l in lines if "AI API:" in l and "http://" in l
+        ]
+        self.assertEqual(len(urls), 1)
+        self.assertIn("!AI_PORT!", urls[0])
+
+    def test_updater_url_uses_updater_port(self):
+        """Updater message uses !UPDATER_PORT!."""
+        lines = self._get_lines()
+        urls = [
+            l for l in lines if "Updater:" in l and "http://" in l
+        ]
+        self.assertEqual(len(urls), 1)
+        self.assertIn("!UPDATER_PORT!", urls[0])
+
+    def test_browser_open_uses_app_port(self):
+        """Browser open uses !APP_PORT!."""
+        lines = self._get_lines()
+        browser = [
+            l for l in lines if l.startswith('start "" http://')
+        ]
+        self.assertEqual(len(browser), 1)
+        self.assertIn("!APP_PORT!", browser[0])
+        self.assertIn("/main.html", browser[0])
+
+
+class TestDelayedExpansionUsed(unittest.TestCase):
+    """Verify delayedexpansion is enabled (prerequisite for !VAR! syntax)."""
+
+    def test_enabledelayedexpansion_present(self):
+        text = BATCH_PATH.read_text()
+        self.assertIn("setlocal enabledelayedexpansion", text)
+
+
+class TestPortBlockPlacement(unittest.TestCase):
+    """The port config block must appear before any port usage."""
+
+    def test_port_before_any_server_reference(self):
+        """Port variable defines must appear before start_ai_server / start_web labels."""
+        text = BATCH_PATH.read_text()
+        lines = text.splitlines()
+
+        # Find the port block: it starts with a REM about reading port config
+        port_block_idx = None
+        for i, line in enumerate(lines):
+            if "Read port configuration from environment" in line:
+                port_block_idx = i
+                break
+
+        self.assertIsNotNone(port_block_idx, "Port config block not found")
+
+        # It must appear before :start_ai_server and :start_web labels
+        start_ai_idx = next(
+            (i for i, l in enumerate(lines) if l.strip() == ":start_ai_server"),
+            None,
+        )
+        start_web_idx = next(
+            (i for i, l in enumerate(lines) if l.strip() == ":start_web"),
+            None,
+        )
+
+        self.assertIsNotNone(start_ai_idx, "start_ai_server label should exist")
+        self.assertIsNotNone(start_web_idx, "start_web label should exist")
+        pbi: int = port_block_idx  # type: ignore[assignment]
+        ai: int = start_ai_idx  # type: ignore[assignment]
+        web: int = start_web_idx  # type: ignore[assignment]
+        self.assertTrue(pbi < ai)
+        self.assertTrue(pbi < web)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_start_bat_env.py
+++ b/tests/test_start_bat_env.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Tests for start.bat .env file sourcing behavior.
+
+Verifies that start.bat:
+  - Checks for .env file existence before parsing
+  - Parses KEY=VALUE pairs from .env via PowerShell
+  - Echoes "[*] Loaded .env" when .env exists
+  - Comment lines (starting with #) are ignored by the regex
+  - Values with spaces are captured correctly
+  - Default ports still work when .env is absent
+  - The .env parsing block appears before port variable definitions
+"""
+
+import re
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BATCH_PATH = ROOT / "start.bat"
+
+
+class TestEnvFileExistenceCheck(unittest.TestCase):
+    """AC1: start.bat checks for .env file before parsing."""
+
+    def test_env_existence_branch_exists(self):
+        """The script contains 'if exist ".env" ( ... )' construct."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('if exist ".env"', text)
+
+    def test_conditional_block_closes(self):
+        """The if exist .env block is properly closed with ) after the echo."""
+        text = BATCH_PATH.read_text()
+        lines = text.splitlines()
+
+        # Find the "if exist" line
+        if_line_idx = None
+        for i, line in enumerate(lines):
+            if 'if exist ".env"' in line:
+                if_line_idx = i
+                break
+
+        self.assertIsNotNone(if_line_idx, "if exist '.env' not found")
+
+        # After the PowerShell command and the two echo lines, there should be a closing )
+        # that is not indented (same level as 'if')
+        block_end_found = False
+        for i in range(if_line_idx + 1, min(if_line_idx + 10, len(lines))):
+            stripped = lines[i].strip()
+            if stripped == ")":
+                block_end_found = True
+                break
+
+        self.assertTrue(block_end_found, "Expected closing ')' for .env if block not found")
+
+
+class TestEnvParsingViaPowerShell(unittest.TestCase):
+    """AC4: PowerShell inline reads .env and sets process-level env vars."""
+
+    def test_powerShell_command_present(self):
+        """The PowerShell command is present as an inline invocation."""
+        text = BATCH_PATH.read_text()
+        self.assertIn("PowerShell -NoProfile -Command", text)
+
+    def test_Get_Env_uses_UTF8_encoding(self):
+        """The PowerShell reader uses UTF-8 encoding."""
+        text = BATCH_PATH.read_text()
+        self.assertIn("Get-Content '.env' -Encoding UTF8", text)
+
+    def test_SetEnvironmentVariable_Protocol_set(self):
+        """Environment vars are set at Process scope."""
+        text = BATCH_PATH.read_text()
+        # Check that SetEnvironmentVariable is used with 'Process'
+        self.assertIn("SetEnvironmentVariable", text)
+        self.assertIn("'Process'", text)
+
+    def test_stderr_suppressed(self):
+        """PowerShell stderr is suppressed with 2>nul."""
+        text = BATCH_PATH.read_text()
+        self.assertIn("2>nul", text)
+
+    def test_regex_pattern_for_key_value(self):
+        """The regex matches KEY=VALUE format for valid env var names."""
+        text = BATCH_PATH.read_text()
+        # The regex should match typical env var names: letters, digits, underscores
+        self.assertIn("([A-Za-z_][A-Za-z0-9_]*)", text)
+        # And should capture the value
+        self.assertIn("(.+?)", text)
+
+
+class TestEnvEchoOutput(unittest.TestCase):
+    """AC5: echo "[*] Loaded .env" appears when .env exists."""
+
+    def test_loaded_env_echo_present(self):
+        """The echo '[*] Loaded .env' message is present."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('echo [*] Loaded .env', text)
+
+    def test_loaded_env_echo_in_env_block(self):
+        """The echo is inside the 'if exist .env' block."""
+        text = BATCH_PATH.read_text()
+        lines = text.splitlines()
+
+        if_line_idx = None
+        brace_close = None
+        for i, line in enumerate(lines):
+            if 'if exist ".env"' in line:
+                if_line_idx = i
+            if if_line_idx is not None and line.strip() == ")":
+                brace_close = i
+                break
+
+        self.assertIsNotNone(if_line_idx, "if exist '.env' not found")
+        self.assertIsNotNone(brace_close, "Close parenthesis for if block not found")
+
+        found = False
+        for i in range(if_line_idx + 1, brace_close):
+            if "Loaded .env" in lines[i]:
+                found = True
+                break
+        self.assertTrue(found, "Loaded .env echo not inside the .env if block")
+
+
+class TestPowerShellRegexHandlesEnvFileFormats(unittest.TestCase):
+    """Test that the PowerShell regex correctly parses different .env formats."""
+
+    # The regex from start.bat, adapted to Python
+    # Batch: '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$'
+    _ENV_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*$")
+
+    def _parse_env_lines(self, text):
+        """Simulate the PowerShell regex parse in Python."""
+        result = {}
+        for line in text.splitlines():
+            m = self._ENV_RE.match(line)
+            if m:
+                result[m.group(1)] = m.group(2)
+        return result
+
+    def test_basic_key_value(self):
+        """Simple KEY=VALUE pairs are parsed."""
+        env_text = "WRITINGWAY_PORT=9000"
+        pairs = self._parse_env_lines(env_text)
+        self.assertEqual(pairs["WRITINGWAY_PORT"], "9000")
+
+    def test_multiple_variables(self):
+        """Multiple KEY=VALUE pairs are all parsed."""
+        env_text = textwrap.dedent("""\
+            WRITINGWAY_PORT=9000
+            WRITINGWAY_UPDATER_PORT=9001
+            WRITINGWAY_AI_PORT=9080
+        """)
+        pairs = self._parse_env_lines(env_text)
+        self.assertEqual(pairs["WRITINGWAY_PORT"], "9000")
+        self.assertEqual(pairs["WRITINGWAY_UPDATER_PORT"], "9001")
+        self.assertEqual(pairs["WRITINGWAY_AI_PORT"], "9080")
+
+    def test_comments_ignored(self):
+        """Lines starting with # (optionally with leading whitespace) are ignored."""
+        env_text = textwrap.dedent("""\
+            # This is a comment
+            WRITINGWAY_PORT=9000
+            # Another comment
+            WRITINGWAY_AI_PORT=8080
+        """)
+        pairs = self._parse_env_lines(env_text)
+        self.assertNotIn("# This is a comment", pairs)
+        self.assertEqual(pairs["WRITINGWAY_PORT"], "9000")
+        self.assertEqual(pairs["WRITINGWAY_AI_PORT"], "8080")
+        self.assertNotIn("# Another comment", pairs)
+
+    def test_empty_lines_ignored(self):
+        """Blank lines do not produce entries."""
+        env_text = textwrap.dedent("""\
+            WRITINGWAY_PORT=9000
+
+            WRITINGWAY_AI_PORT=8080
+        """)
+        pairs = self._parse_env_lines(env_text)
+        self.assertEqual(pairs["WRITINGWAY_PORT"], "9000")
+        self.assertEqual(pairs["WRITINGWAY_AI_PORT"], "8080")
+        self.assertNotIn("", pairs)
+
+    def test_values_with_spaces(self):
+        """Values containing spaces are captured correctly."""
+        env_text = "DESCRIPTION=Writingway AI server"
+        pairs = self._parse_env_lines(env_text)
+        # 'DESCRIPTION' is a valid var name; the value should include spaces
+        self.assertIn("DESCRIPTION", pairs)
+        self.assertEqual(pairs["DESCRIPTION"], "Writingway AI server")
+
+    def test_values_with_spaces_corrected(self):
+        """Values containing spaces after = are correctly captured."""
+        env_text = "MY_VAR=hello world foo"
+        pairs = self._parse_env_lines(env_text)
+        # The regex (.+?)\s*$ captures up to trailing whitespace
+        self.assertEqual(pairs.get("MY_VAR", ""), "hello world foo")
+
+    def test_comment_with_leading_whitespace(self):
+        """Comment lines with leading whitespace are ignored."""
+        env_text = "  # indented comment"
+        pairs = self._parse_env_lines(env_text)
+        self.assertNotIn("# indented comment", pairs)
+        # Also check the key part isn't parsed
+        for key in pairs:
+            # The line starts with whitespace then #, so the regex's
+            # ([A-Za-z_][A-Za-z0-9_]*) won't match because after whitespace,
+            # the first char is # which is not [A-Za-z_]
+            self.assertFalse(key.startswith("#"))
+
+    def test_value_trimmed_of_trailing_whitespace(self):
+        """Trailing whitespace is stripped from values by \s*$."""
+        env_text = "WRITINGWAY_PORT=8000   "
+        pairs = self._parse_env_lines(env_text)
+        self.assertEqual(pairs["WRITINGWAY_PORT"], "8000")
+
+    def test_value_trimmed_of_leading_whitespace_after_eq(self):
+        """Leading whitespace after = is stripped by \s* in regex."""
+        env_text = "WRITINGWAY_PORT=  8000"
+        pairs = self._parse_env_lines(env_text)
+        self.assertEqual(pairs["WRITINGWAY_PORT"], "8000")
+
+    def test_underscore_in_var_name(self):
+        """Variable names with underscores are valid."""
+        env_text = "WRITINGWAY_AI_PORT=8080"
+        pairs = self._parse_env_lines(env_text)
+        self.assertEqual(pairs["WRITINGWAY_AI_PORT"], "8080")
+
+    def test_var_starts_with_underscore(self):
+        """Variable names starting with _ are valid."""
+        env_text = "_PRIVATE_VAR=test"
+        pairs = self._parse_env_lines(env_text)
+        self.assertEqual(pairs["_PRIVATE_VAR"], "test")
+
+
+class TestDefaultsWorkWhenEnvAbsent(unittest.TestCase):
+    """AC2: When .env is absent, defaults to 8000, 8001, 8080."""
+
+    def test_port_block_follows_env_check(self):
+        """Port variable definitions come after the .env if block."""
+        text = BATCH_PATH.read_text()
+        lines = text.splitlines()
+
+        env_block_close = None
+        port_defs_start = None
+        for i, line in enumerate(lines):
+            if 'if exist ".env"' in line:
+                # Find the closing )
+                for j in range(i + 1, min(i + 15, len(lines))):
+                    if lines[j].strip() == ")":
+                        env_block_close = j
+                        break
+            if port_defs_start is None and "set \"APP_PORT=%WRITINGWAY_PORT%\"" in line:
+                port_defs_start = i
+
+        self.assertIsNotNone(env_block_close, "Env if block not found")
+        self.assertIsNotNone(port_defs_start, "Port definition not found")
+        self.assertTrue(env_block_close < port_defs_start)
+
+    def test_default_port_lines_still_present(self):
+        """Default values are set when env vars are empty."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('set "APP_PORT=8000"', text)
+        self.assertIn('set "UPDATER_PORT=8001"', text)
+        self.assertIn('set "AI_PORT=8080"', text)
+
+    def test_no_env_no_crash(self):
+        """When .env is absent, the if exist block is skipped entirely."""
+        text = BATCH_PATH.read_text()
+        lines = text.splitlines()
+
+        # The script must have 'if exist ".env"' (not 'if not exist' or other negation)
+        env_check_line = None
+        for line in lines:
+            if 'if exist ".env"' in line:
+                env_check_line = line
+                break
+
+        self.assertIsNotNone(env_check_line, "Env existence check not found")
+        # Verify it does NOT use negation
+        self.assertNotIn("if not exist", env_check_line)
+
+
+class TestEnvBlockPlacement(unittest.TestCase):
+    """The .env block must appear before all server-start commands."""
+
+    def test_env_before_app_server_start(self):
+        """.env parsing happens before python tools\\writingway-server.py."""
+        text = BATCH_PATH.read_text()
+        lines = text.splitlines()
+
+        env_block_close = None
+        server_stop_idx = None
+        for i, line in enumerate(lines):
+            if 'if exist ".env"' in line:
+                for j in range(i + 1, min(i + 15, len(lines))):
+                    if lines[j].strip() == ")":
+                        env_block_close = j
+                        break
+            if "writingway-server.py" in line:
+                server_stop_idx = i
+
+        self.assertIsNotNone(env_block_close)
+        self.assertIsNotNone(server_stop_idx)
+        self.assertTrue(env_block_close < server_stop_idx)
+
+
+class TestBatchSyntaxIntegrity(unittest.TestCase):
+    """Ensure the batch file modifications did not break core syntax."""
+
+    def test_delayed_expansion_still_enabled(self):
+        """setlocal enabledelayedexpansion must still be present."""
+        text = BATCH_PATH.read_text()
+        self.assertIn("setlocal enabledelayedexpansion", text)
+
+    def test_port_variable_syntax_uses_delayed(self):
+        """All port variable references use !VAR! syntax."""
+        text = BATCH_PATH.read_text()
+        # The default-value assignments use %VAR% which is normal for
+        # batch's 'if empty' pattern: if "!VAR!"=="" set "VAR=default"
+        self.assertIn('set "APP_PORT=%WRITINGWAY_PORT%"', text)
+        self.assertIn('set "UPDATER_PORT=%WRITINGWAY_UPDATER_PORT%"', text)
+        self.assertIn('set "AI_PORT=%WRITINGWAY_AI_PORT%"', text)
+
+    def test_port_emptiness_checks_unchanged(self):
+        """Default fallback pattern is preserved."""
+        text = BATCH_PATH.read_text()
+        self.assertIn('if "!APP_PORT!"=="" set "APP_PORT=8000"', text)
+        self.assertIn('if "!UPDATER_PORT!"=="" set "UPDATER_PORT=8001"', text)
+        self.assertIn('if "!AI_PORT!"=="" set "AI_PORT=8080"', text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_start_sh_t3.sh
+++ b/tests/test_start_sh_t3.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# Tests for start.sh port-env refactoring (T3)
+# Verifies: .env sourcing, variable substitution, default behavior, set -a exports
+#
+# Usage: bash tests/test_start_sh_t3.sh
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_PATH="$(cd "$(dirname "$0")/.." && pwd)/start.sh"
+
+pass_test() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail_test() {
+    echo "  FAIL: $1 — $2"
+    FAIL=$((FAIL + 1))
+}
+
+# Check that a plain text string appears in the file (fixed string match)
+check_in() {
+    if grep -qF "$2" "$1" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+# Check that a regex pattern appears in the file
+check_regex() {
+    if grep -qE "$2" "$1" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+echo ""
+echo "====================================="
+echo "  Tests for start.sh (T3)"
+echo "====================================="
+echo ""
+
+# ── Test Group 1: .env sourcing ──
+echo "[1] .env file sourcing"
+check_in "$SCRIPT_PATH" 'if [ -f ".env" ]' && \
+    pass_test ".env existence check" || \
+    fail_test ".env existence check" "pattern 'if [ -f \".env\" ]' not found"
+
+check_in "$SCRIPT_PATH" 'set -a; . ./.env; set +a' && \
+    pass_test "set -a/.env/set +a block" || \
+    fail_test "set -a/.env/set +a block" "pattern not found"
+
+check_in "$SCRIPT_PATH" '[*] Loaded .env' && \
+    pass_test "Echo message after .env is loaded" || \
+    fail_test "Echo message after .env is loaded" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'APP_PORT="${WRITINGWAY_PORT:-8000}"' && \
+    pass_test "APP_PORT variable defined with default 8000" || \
+    fail_test "APP_PORT variable defined with default 8000" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'UPDATER_PORT="${WRITINGWAY_UPDATER_PORT:-8001}"' && \
+    pass_test "UPDATER_PORT variable defined with default 8001" || \
+    fail_test "UPDATER_PORT variable defined with default 8001" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'AI_PORT="${WRITINGWAY_AI_PORT:-8080}"' && \
+    pass_test "AI_PORT variable defined with default 8080" || \
+    fail_test "AI_PORT variable defined with default 8080" "pattern not found"
+
+# Verify .env sourcing happens AFTER Python check block
+PYTHON_LINE=$(grep -n 'echo "\[OK\] Python 3 found"' "$SCRIPT_PATH" | head -1 | cut -d: -f1)
+ENV_LINE=$(grep -n 'if \[ -f ".env" \]' "$SCRIPT_PATH" | head -1 | cut -d: -f1)
+[ "$ENV_LINE" -gt "$PYTHON_LINE" ] && \
+    pass_test ".env sourcing after Python check (line $ENV_LINE > $PYTHON_LINE)" || \
+    fail_test ".env sourcing placement" "line $ENV_LINE <= $PYTHON_LINE"
+
+# ── Test Group 2: Hardcoded ports replaced ──
+echo ""
+echo "[2] Hardcoded ports replaced with variables"
+
+# Use grep to find the actual llama-server command (starts with ./llama/)
+LLAMA_CMD=$(grep '^\s*./llama/llama-server' "$SCRIPT_PATH" | head -1)
+if [ -z "$LLAMA_CMD" ]; then
+    # Fallback: look for line with both llama-server and --port
+    LLAMA_CMD=$(grep 'llama-server.*--port' "$SCRIPT_PATH" | head -1)
+fi
+echo "$LLAMA_CMD" | grep -qF -- '--port "$AI_PORT"' && \
+    pass_test "llama-server uses \$AI_PORT" || \
+    fail_test "llama-server uses \$AI_PORT" "line: $LLAMA_CMD"
+
+# AI health check — extract the curl line for AI health
+AI_HEALTH_LINE=$(grep 'health' "$SCRIPT_PATH" | grep 'curl' | head -1)
+echo "$AI_HEALTH_LINE" | grep -qF -- '$AI_PORT/health' && \
+    pass_test "AI health check uses \$AI_PORT" || \
+    fail_test "AI health check uses \$AI_PORT" "line: $AI_HEALTH_LINE"
+
+check_in "$SCRIPT_PATH" 'AI server starting on port $AI_PORT' && \
+    pass_test "AI echo message uses \$AI_PORT" || \
+    fail_test "AI echo message uses \$AI_PORT" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'Updater service started on port $UPDATER_PORT' && \
+    pass_test "Updater echo uses \$UPDATER_PORT" || \
+    fail_test "Updater echo uses \$UPDATER_PORT" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'Starting app server on port $APP_PORT' && \
+    pass_test "App server echo uses \$APP_PORT" || \
+    fail_test "App server echo uses \$APP_PORT" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'http://localhost:$APP_PORT/main.html' && \
+    pass_test "URL status messages use \$APP_PORT" || \
+    fail_test "URL status messages use \$APP_PORT" "pattern not found"
+
+APP_HEALTH_LINE=$(grep 'api/health' "$SCRIPT_PATH" | grep 'curl' | head -1)
+echo "$APP_HEALTH_LINE" | grep -qF -- '$APP_PORT/api/health' && \
+    pass_test "App health check uses \$APP_PORT" || \
+    fail_test "App health check uses \$APP_PORT" "line: $APP_HEALTH_LINE"
+
+check_in "$SCRIPT_PATH" 'open "http://localhost:$APP_PORT/main.html"' && \
+    pass_test "macOS open uses \$APP_PORT" || \
+    fail_test "macOS open uses \$APP_PORT" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'xdg-open "http://localhost:$APP_PORT/main.html"' && \
+    pass_test "Linux xdg-open uses \$APP_PORT" || \
+    fail_test "Linux xdg-open uses \$APP_PORT" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'AI API: http://localhost:$AI_PORT' && \
+    pass_test "AI API status message uses \$AI_PORT" || \
+    fail_test "AI API status message uses \$AI_PORT" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'Updater: http://localhost:$UPDATER_PORT' && \
+    pass_test "Updater status message uses \$UPDATER_PORT" || \
+    fail_test "Updater status message uses \$UPDATER_PORT" "pattern not found"
+
+# Verify NO remaining hardcoded ports in messages/urls (excluding variable definition lines 35-37)
+REST=$(sed '35,37d' "$SCRIPT_PATH")
+echo "$REST" | grep -qE '(curl|http)[^0-9]*8080' 2>/dev/null && \
+    fail_test "No hardcoded 8080 in messages" "found in rest of file" || \
+    pass_test "No hardcoded 8080 in messages"
+
+echo "$REST" | grep -qE '(curl|http)[^0-9]*8000' 2>/dev/null && \
+    fail_test "No hardcoded 8000 in messages" "found in rest of file" || \
+    pass_test "No hardcoded 8000 in messages"
+
+echo "$REST" | grep -qE '(curl|http)[^0-9]*8001' 2>/dev/null && \
+    fail_test "No hardcoded 8001 in messages" "found in rest of file" || \
+    pass_test "No hardcoded 8001 in messages"
+
+# ── Test Group 3: Default behavior unchanged ──
+echo ""
+echo "[3] Default behavior (no .env) produces same output"
+check_in "$SCRIPT_PATH" 'WRITINGWAY_PORT:-8000' && \
+    pass_test "Default APP_PORT is 8000" || \
+    fail_test "Default APP_PORT is 8000" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'WRITINGWAY_UPDATER_PORT:-8001' && \
+    pass_test "Default UPDATER_PORT is 8001" || \
+    fail_test "Default UPDATER_PORT is 8001" "pattern not found"
+
+check_in "$SCRIPT_PATH" 'WRITINGWAY_AI_PORT:-8080' && \
+    pass_test "Default AI_PORT is 8080" || \
+    fail_test "Default AI_PORT is 8080" "pattern not found"
+
+# ── Test Group 4: Syntax validation ──
+echo ""
+echo "[4] Syntax validation"
+if bash -n "$SCRIPT_PATH" 2>/dev/null; then
+    pass_test "start.sh passes bash -n syntax check"
+else
+    fail_test "start.sh syntax" "bash -n reported errors"
+fi
+
+# ── Test Group 5: .env sourcing and variable resolution ──
+echo ""
+echo "[5] .env sourcing and variable resolution"
+TMPDIR=$(mktemp -d)
+cp "$SCRIPT_PATH" "$TMPDIR/start_test.sh"
+
+env_content="WRITINGWAY_PORT=9900
+WRITINGWAY_UPDATER_PORT=9901
+WRITINGWAY_AI_PORT=9980"
+printf '%s\n' "$env_content" > "$TMPDIR/.env"
+
+RESULT=$( bash -c "
+    cd '$TMPDIR'
+    if [ -f '.env' ]; then
+        set -a; . ./.env; set +a
+    fi
+    APP_PORT=\"\${WRITINGWAY_PORT:-8000}\"
+    UPDATER_PORT=\"\${WRITINGWAY_UPDATER_PORT:-8001}\"
+    AI_PORT=\"\${WRITINGWAY_AI_PORT:-8080}\"
+    echo \"APP_PORT=\$APP_PORT UPDATER_PORT=\$UPDATER_PORT AI_PORT=\$AI_PORT\"
+" 2>&1 )
+
+echo "$RESULT" | grep -qF 'APP_PORT=9900 UPDATER_PORT=9901 AI_PORT=9980' && \
+    pass_test "Custom .env ports resolved correctly" || \
+    fail_test "Custom .env ports" "got: $RESULT"
+
+# Test with no .env → defaults
+RESULT2=$( bash -c "
+    cd '$TMPDIR'
+    rm -f .env
+    if [ -f '.env' ]; then
+        set -a; . ./.env; set +a
+    fi
+    APP_PORT=\"\${WRITINGWAY_PORT:-8000}\"
+    UPDATER_PORT=\"\${WRITINGWAY_UPDATER_PORT:-8001}\"
+    AI_PORT=\"\${WRITINGWAY_AI_PORT:-8080}\"
+    echo \"APP_PORT=\$APP_PORT UPDATER_PORT=\$UPDATER_PORT AI_PORT=\$AI_PORT\"
+" 2>&1 )
+
+echo "$RESULT2" | grep -qF 'APP_PORT=8000 UPDATER_PORT=8001 AI_PORT=8080' && \
+    pass_test "Default ports without .env" || \
+    fail_test "Default ports without .env" "got: $RESULT2"
+
+# Test set -a exports — child processes should inherit
+RESULT3=$( bash -c "
+    cd '$TMPDIR'
+    printf 'MYVAR=hello\n' > .env
+    set -a; . ./.env; set +a
+    # Subshell should inherit MYVAR from exported variable
+    bash -c 'echo CHILD_VALUE=\$MYVAR'
+" 2>&1 )
+
+echo "$RESULT3" | grep -qF 'CHILD_VALUE=hello' && \
+    pass_test "set -a exports to child processes" || \
+    fail_test "set -a exports" "got: $RESULT3"
+
+# Cleanup
+rm -rf "$TMPDIR"
+
+# ── Summary ──
+echo ""
+echo "====================================="
+TOTAL=$((PASS + FAIL))
+echo "  Results: $PASS passed, $FAIL failed (out of $TOTAL)"
+echo "====================================="
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/tests/test_t6_ai_port.py
+++ b/tests/test_t6_ai_port.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Tests for T6: dynamic AI port from WritingwayConfig replaces hardcoded localhost:8080."""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC_AI = ROOT / "src" / "ai.js"
+SRC_GEN = ROOT / "src" / "generation.js"
+SRC_AI_SETTINGS = ROOT / "src" / "modules" / "ai-settings.js"
+
+# The expected dynamic port pattern
+DYNAMIC_PORT_RE = re.compile(
+    r"typeof\s+window\.WritingwayConfig\s*!==\s*'undefined'"
+)
+FALLBACK_RE = re.compile(r"\?\s*window\.WritingwayConfig\.aiPort\s*:\s*8080")
+localhost_8080_RE = re.compile(r"localhost:8080")
+
+
+class TestNoHardcodedLocalhost8080InAISource(unittest.TestCase):
+    """AC: No hardcoded 'http://localhost:8080' remains in the three modified modules."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ai_content = SRC_AI.read_text()
+        cls.gen_content = SRC_GEN.read_text()
+        cls.ai_settings_content = SRC_AI_SETTINGS.read_text()
+
+    def test_ai_js_no_hardcoded_8080(self):
+        """src/ai.js must not contain 'localhost:8080'."""
+        self.assertNotIn(
+            "localhost:8080",
+            self.ai_content,
+            "src/ai.js still contains hardcoded localhost:8080",
+        )
+
+    def test_generation_js_no_hardcoded_8080(self):
+        """src/generation.js must not contain 'localhost:8080'."""
+        self.assertNotIn(
+            "localhost:8080",
+            self.gen_content,
+            "src/generation.js still contains hardcoded localhost:8080",
+        )
+
+    def test_ai_settings_js_no_hardcoded_8080(self):
+        """src/modules/ai-settings.js must not contain 'localhost:8080'."""
+        self.assertNotIn(
+            "localhost:8080",
+            self.ai_settings_content,
+            "src/modules/ai-settings.js still contains hardcoded localhost:8080",
+        )
+
+
+class TestDynamicPortPatternPresent(unittest.TestCase):
+    """AC: Every modified module uses the typeof window.WritingwayConfig pattern."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ai_content = SRC_AI.read_text()
+        cls.gen_content = SRC_GEN.read_text()
+        cls.ai_settings_content = SRC_AI_SETTINGS.read_text()
+
+    def test_ai_js_uses_dynamic_port(self):
+        """src/ai.js defines defaultAIPort via WritingwayConfig."""
+        self.assertIsNotNone(
+            DYNAMIC_PORT_RE.search(self.ai_content),
+            "src/ai.js does not use the WritingwayConfig pattern",
+        )
+
+    def test_generation_js_uses_dynamic_port(self):
+        """src/generation.js defines defaultAIPort via WritingwayConfig."""
+        self.assertIsNotNone(
+            DYNAMIC_PORT_RE.search(self.gen_content),
+            "src/generation.js does not use the WritingwayConfig pattern",
+        )
+
+    def test_ai_settings_js_uses_dynamic_port(self):
+        """src/modules/ai-settings.js defines defaultAIPort via WritingwayConfig."""
+        matches = DYNAMIC_PORT_RE.findall(self.ai_settings_content)
+        self.assertGreaterEqual(
+            len(matches),
+            3,
+            f"Expected at least 3 WritingwayConfig usages in ai-settings.js, found {len(matches)}",
+        )
+
+
+class TestFallbackTo8080(unittest.TestCase):
+    """AC: Graceful fallback to 8080 when WritingwayConfig is unavailable."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ai_content = SRC_AI.read_text()
+        cls.gen_content = SRC_GEN.read_text()
+        cls.ai_settings_content = SRC_AI_SETTINGS.read_text()
+
+    def test_ai_js_fallback(self):
+        """src/ai.js falls back to 8080."""
+        self.assertIsNotNone(
+            FALLBACK_RE.search(self.ai_content),
+            "src/ai.js missing fallback to 8080 in ternary",
+        )
+
+    def test_generation_js_fallback(self):
+        """src/generation.js falls back to 8080."""
+        self.assertIsNotNone(
+            FALLBACK_RE.search(self.gen_content),
+            "src/generation.js missing fallback to 8080 in ternary",
+        )
+
+    def test_ai_settings_js_fallback(self):
+        """src/modules/ai-settings.js falls back to 8080."""
+        self.assertGreaterEqual(
+            len(FALLBACK_RE.findall(self.ai_settings_content)),
+            3,
+            "src/modules/ai-settings.js should have at least 3 fallback patterns",
+        )
+
+
+class TestLocalStorageEndpointPreserved(unittest.TestCase):
+    """AC: localStorage user overrides (app.aiEndpoint) are checked first."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.gen_content = SRC_GEN.read_text()
+        cls.ai_settings_content = SRC_AI_SETTINGS.read_text()
+
+    def test_generation_js_checks_app_aiEndpoint_first(self):
+        """src/generation.js checks app.aiEndpoint before dynamic fallback."""
+        # The pattern is: app?.aiEndpoint || 'http://localhost:' + defaultAIPort
+        # So app.aiEndpoint must be checked first
+        match = re.search(
+            r"app\?\.aiEndpoint\s*\|\|\s*'http://localhost:'",
+            self.gen_content,
+        )
+        self.assertIsNotNone(
+            match,
+            "src/generation.js should check app.aiEndpoint before default fallback",
+        )
+
+    def test_ai_js_checks_app_aiEndpoint_first(self):
+        """src/ai.js checks app.aiEndpoint before dynamic fallback."""
+        match = re.search(
+            r"app\.aiEndpoint\s*\|\|\s*'http://localhost:'",
+            SRC_AI.read_text(),
+        )
+        self.assertIsNotNone(
+            match,
+            "src/ai.js should check app.aiEndpoint before default fallback",
+        )
+
+
+class TestConfigModuleIntegration(unittest.TestCase):
+    """AC: config.js provides WritingwayConfig with aiPort."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config_content = (ROOT / "src" / "config.js").read_text()
+
+    def test_config_has_aiport(self):
+        """config.js sets aiPort default."""
+        self.assertIn("aiPort: 8080", self.config_content)
+
+    def test_config_fetches_writingway_json(self):
+        """config.js fetches /writingway.json."""
+        self.assertIn("/writingway.json", self.config_content)
+
+    def test_config_aiPort_override(self):
+        """config.js reads aiPort from /writingway.json."""
+        self.assertIn("data.aiPort", self.config_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit-config-integration.js
+++ b/tests/unit-config-integration.js
@@ -1,0 +1,204 @@
+const { chromium } = require('playwright');
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Tests for config.js and update-checker.js integration (T5).
+ *
+ * Tests:
+ *  1. config.js defines window.WritingwayConfig with correct defaults (fallback)
+ *  2. config.js fetches /writingway.json and overwrites defaults
+ *  3. update-checker.js uses the dynamic updaterUrl (updated if WritingwayConfig is available)
+ *  4. Fallback to http://127.0.0.1:8001 works when config endpoint unavailable
+ *  5. Script tag order: config.js before update-checker.js in main.html
+ */
+
+const ROOT = path.resolve(__dirname, '..');
+const TEST_PORT = 18923;
+
+// ---------- tiny test server that serves the project root + /writingway.json ----------
+function createTestServer(root, port, configJson) {
+    return new Promise((resolve) => {
+        const server = http.createServer((req, res) => {
+            if (req.url === '/writingway.json') {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(configJson));
+                return;
+            }
+            // Fallback to static file serving
+            let filePath = path.join(root, req.url === '/' ? 'main.html' : req.url);
+            fs.readFile(filePath, (err, data) => {
+                if (err) {
+                    res.writeHead(404);
+                    res.end('Not found');
+                    return;
+                }
+                res.writeHead(200);
+                res.end(data);
+            });
+        });
+        server.listen(port, '127.0.0.1', () => resolve(server));
+    });
+}
+
+// ---------- helpers ----------
+function log(label, ok) {
+    console.log(ok ? `  ✓ ${label}` : `  ✗ ${label}`);
+}
+
+async function runTests() {
+    const results = []; // { ac, pass, detail }
+    const addResult = (ac, pass, detail) => {
+        results.push({ ac, pass, detail });
+        log(ac, pass);
+    };
+
+    const expectedConfig = { port: 9900, updaterPort: 9901, aiPort: 9980 };
+
+    // ---- Test 5 (no server needed) ----
+    {
+        const mainHtml = fs.readFileSync(path.join(ROOT, 'main.html'), 'utf8');
+        const configIdx = mainHtml.indexOf('src/config.js');
+        const updateCheckerIdx = mainHtml.indexOf('src/update-checker.js');
+        const pass = configIdx !== -1 && updateCheckerIdx !== -1 && configIdx < updateCheckerIdx;
+        addResult(
+            '[AC5] config.js script tag before update-checker.js in main.html',
+            pass,
+            pass ? `config.js at index ${configIdx}, update-checker.js at ${updateCheckerIdx}` : `config.js idx=${configIdx}, update-checker.js idx=${updateCheckerIdx}`
+        );
+    }
+
+    // ---- Test AC1: config.js defines defaults ----
+    {
+        const configJs = fs.readFileSync(path.join(ROOT, 'src/config.js'), 'utf8');
+        const pass = configJs.includes('port: 8000') &&
+                     configJs.includes('updaterPort: 8001') &&
+                     configJs.includes('aiPort: 8080') &&
+                     configJs.includes('window.WritingwayConfig = config');
+        addResult(
+            '[AC1] src/config.js defines window.WritingwayConfig with port, updaterPort, aiPort (defaults 8000, 8001, 8080)',
+            pass,
+            pass ? 'All three defaults present in config.js' : 'Expected defaults not found in config.js'
+        );
+    }
+
+    // ---- Test AC2: config.js fetches /writingway.json and silently fails on error ----
+    {
+        const configJs = fs.readFileSync(path.join(ROOT, 'src/config.js'), 'utf8');
+        const hasFetch = configJs.includes("fetch('/writingway.json')");
+        const hasSilentFailure = configJs.includes('.catch(') && configJs.includes('function');
+        const pass = hasFetch && hasSilentFailure;
+        addResult(
+            '[AC2] src/config.js fetches /writingway.json and silently fails on error',
+            pass,
+            pass ? 'fetch + .catch pattern found' : 'Missing fetch or .catch pattern'
+        );
+    }
+
+    // ---- Test AC3: update-checker.js overrides updaterUrl from WritingwayConfig ----
+    {
+        const updateCheckerJs = fs.readFileSync(path.join(ROOT, 'src/update-checker.js'), 'utf8');
+        const hasOverride = updateCheckerJs.includes('window.WritingwayConfig') &&
+                            updateCheckerJs.includes('WritingwayConfig.updaterPort') &&
+                            updateCheckerJs.includes('UpdateChecker.updaterUrl');
+        addResult(
+            '[AC3] src/update-checker.js uses dynamic updaterUrl from WritingwayConfig',
+            hasOverride,
+            hasOverride ? 'Override logic found at end of IIFE' : 'Override logic not found'
+        );
+    }
+
+    // ---- Test AC4: Dynamic integration test (browser + server) ----
+    let server;
+    try {
+        server = await createTestServer(ROOT, TEST_PORT, expectedConfig);
+    } catch (err) {
+        console.error('Failed to start test server:', err.message);
+        addResult('[AC4] Dynamic: config fetch + override', false, 'server startup error: ' + err.message);
+        addResult('[AC4] Fallback to default when config unavailable', false, 'server startup error: ' + err.message);
+    }
+
+    if (server) {
+        let browser;
+        try {
+            browser = await chromium.launch({ headless: true });
+            const context = await browser.newContext();
+            const page = await context.newPage();
+
+            page.on('console', (msg) => {
+                if (msg.type() === 'error') {
+                    console.log('    PAGE ERROR:', msg.text());
+                }
+            });
+
+            // ---- AC4a: config.js fetches /writingway.json and updates the shared object ----
+            {
+                await page.goto(`http://127.0.0.1:${TEST_PORT}/main.html`, { waitUntil: 'load', timeout: 15000 });
+                await new Promise((r) => setTimeout(r, 1500));
+
+                const result = await page.evaluate(() => {
+                    const config = window.WritingwayConfig || {};
+                    return {
+                        port: config.port,
+                        updaterPort: config.updaterPort,
+                        aiPort: config.aiPort,
+                    };
+                });
+
+                // The shared config object must be mutated to server values
+                const pass = result.port === expectedConfig.port &&
+                             result.updaterPort === expectedConfig.updaterPort &&
+                             result.aiPort === expectedConfig.aiPort;
+                addResult(
+                    '[AC4] Dynamic: config.js fetches /writingway.json and overrides defaults',
+                    pass,
+                    `WritingwayConfig={port:${result.port}, updaterPort:${result.updaterPort}, aiPort:${result.aiPort}} ${pass ? '✓' : '✗'} (expected port:${expectedConfig.port}, updaterPort:${expectedConfig.updaterPort}, aiPort:${expectedConfig.aiPort})`
+                );
+            }
+
+            // ---- AC4b: Fallback to default when config endpoint unavailable ----
+            server.close();
+            server = null;
+
+            {
+                const updateCheckerJs = fs.readFileSync(path.join(ROOT, 'src/update-checker.js'), 'utf8');
+                const hasFallback = updateCheckerJs.includes("http://127.0.0.1:8001");
+                const configJs = fs.readFileSync(path.join(ROOT, 'src/config.js'), 'utf8');
+                const hasConfigFallback = configJs.includes('port: 8000');
+                const pass = hasFallback && hasConfigFallback;
+                addResult(
+                    '[AC4] Fallback to http://127.0.0.1:8001 works when config unavailable',
+                    pass,
+                    pass ? 'Hardcoded fallback URL present in update-checker.js + config.js defaults intact' : 'Fallback URL missing'
+                );
+            }
+        } catch (err) {
+            console.error('Browser test error:', err.message);
+            addResult('[AC4] Dynamic: config fetch + override', false, err.message);
+            addResult('[AC4] Fallback to default when config unavailable', false, err.message);
+        } finally {
+            if (browser) await browser.close();
+        }
+    }
+
+    // ---- Summary ----
+    const allPassed = results.every((r) => r.pass);
+    console.log('\n' + '='.repeat(60));
+    console.log(`Results: ${results.filter((r) => r.pass).length}/${results.length} tests passed`);
+    if (!allPassed) {
+        console.log('Failed:');
+        results.forEach((r) => {
+            if (!r.pass) console.log(`  - ${r.ac}: ${r.detail}`);
+        });
+    }
+    console.log('='.repeat(60));
+
+    await server && server.close();
+    process.exit(allPassed ? 0 : 1);
+}
+
+runTests().catch((err) => {
+    console.error('Test runner error:', err.message);
+    process.exit(1);
+});

--- a/tools/updater-server.py
+++ b/tools/updater-server.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 # Configuration
 HOST = '127.0.0.1'
-PORT = 8001
+PORT = int(os.environ.get('WRITINGWAY_UPDATER_PORT', '8001'))
 REPO_OWNER = 'aomukai'
 REPO_NAME = 'Writingway2'
 BRANCH = 'main'

--- a/tools/writingway-server.py
+++ b/tools/writingway-server.py
@@ -27,7 +27,7 @@ from urllib.parse import parse_qs, urlparse
 
 
 HOST = "127.0.0.1"
-PORT = 8000
+PORT = int(os.environ.get("WRITINGWAY_PORT", "8000"))
 ROOT = Path(__file__).resolve().parent.parent
 PROJECTS_DIR = ROOT / "projects"
 BACKUPS_DIR = ROOT / "project-backups"
@@ -341,6 +341,13 @@ class WritingwayHandler(SimpleHTTPRequestHandler):
             return
         if parsed.path == "/api/get-backup":
             self.handle_get_backup(parsed.query)
+            return
+        if parsed.path == "/writingway.json":
+            self.respond_json(HTTPStatus.OK, {
+                "port": PORT,
+                "updaterPort": int(os.environ.get("WRITINGWAY_UPDATER_PORT", "8001")),
+                "aiPort": int(os.environ.get("WRITINGWAY_AI_PORT", "8080")),
+            })
             return
         super().do_GET()
 


### PR DESCRIPTION
Some of the default ports are pretty common ports that collide with other common apps, so making them configurable.  I went with ENV variables since there wasn't an established config mechanism for the project, but if you had another config style in mind, I can update to whatever you prefer.

- WRITINGWAY_PORT (default 8000) app server
- WRITINGWAY_UPDATER_PORT (default 8001) updater service
- WRITINGWAY_AI_PORT (default 8080) llama.cpp AI server
- .env file support via start.sh / start.bat
- GET /writingway.json config endpoint on app server
- JS config fetcher module (src/config.js)
- Dynamic port references in launchers, Python servers, and JS clients
- .env.example template and README documentation

All changes are backward-compatible — default values are identical to the previous hardcoded values. No breaking changes for existing users.